### PR TITLE
box template: added mock environment for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.retry
 ansible/vault-password
 rpms/*.rpm
+logs/

--- a/README.md
+++ b/README.md
@@ -4,19 +4,11 @@ Scripts that are used by the PR CI testing infrastructure.
 
 ## Creating vagrant template box
 
-1. Place current RPMs into `rpms/`
-
-   The template box comes with pre-installed FreeIPA dependencies. To install 
-   runtime dependencies, you have to provide RPMs of the target version.
-
-   **TODO**: Use specified git branch to build it automatically during the 
-   box crating process.
-
-2. Run `create-box-template`
+1. Run `create-box-template`
 
    This will create a vagrant box in `/tmp/image/`.
 
-3. Perform some basic tests on the box
+2. Perform some basic tests on the box
 
    **TODO**: Something we want to automate in the future.
 
@@ -28,7 +20,7 @@ Scripts that are used by the PR CI testing infrastructure.
 
    - Verify your recent changes are present
 
-4. Upload the box to [HashiCorp Atlas](https://atlas.hashicorp.com/freeipa)
+3. Upload the box to [HashiCorp Atlas](https://atlas.hashicorp.com/freeipa)
 
    **TODO**: Another step that will be automated in the future.
 
@@ -43,7 +35,7 @@ Scripts that are used by the PR CI testing infrastructure.
      - <change>
    ```
 
-5. Create a PR against FreeIPA with the updated box
+4. Create a PR against FreeIPA with the updated box
 
    **TODO**: This requires GitHub integration with PR CI. Omit this step for
    now and just use the box in Vagrantfiles.

--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -16,6 +16,8 @@
 - hosts: image_box
   name: "modify vagrant box template"
   roles:
+    - role: machine_build_template
+    - role: machine_build  # this caches the packages for mock in root cache
     - role: machine_template
 
 - hosts: runner

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -1,0 +1,6 @@
+---
+freeipa_git_repo: https://github.com/freeipa/freeipa.git
+freeipa_git_branch: master
+build_chroot: fedora-25-x86_64
+freeipa_copr: "@freeipa/freeipa-master"
+

--- a/ansible/roles/box_prepare/tasks/main.yml
+++ b/ansible/roles/box_prepare/tasks/main.yml
@@ -14,11 +14,6 @@
     dest: /tmp/image/Vagrantfile
     mode: 0644
 
-- name: "copy rpms to template box folder"
-  copy:
-    src: ../rpms
-    dest: /tmp/image/
-
 - name: "bring the image online"
   shell: vagrant up
   args:

--- a/ansible/roles/machine_build/tasks/clone_git_repo.yml
+++ b/ansible/roles/machine_build/tasks/clone_git_repo.yml
@@ -1,0 +1,8 @@
+---
+- name: "clone FreeIPA git repo"
+  git:
+    repo: "{{ freeipa_git_repo }}"
+    dest: /root/freeipa
+    version: "{{ freeipa_git_branch }}"
+    depth: 1
+

--- a/ansible/roles/machine_build/tasks/create_rpms.yml
+++ b/ansible/roles/machine_build/tasks/create_rpms.yml
@@ -1,0 +1,15 @@
+---
+- name: "create srpm"
+  shell: |
+    mock --buildsrpm \
+      --spec /root/rpmbuild/SPECS/freeipa.spec \
+      --sources /root/rpmbuild/SOURCES/freeipa-{{ build_version }}.tar.gz \
+      --result /root/rpmbuild/SRPMS/
+
+- name: "create rpms"
+  shell: |
+    mock --rebuild /root/rpmbuild/SRPMS/*.src.rpm \
+      --result /root/rpmbuild/RPMS/
+
+- name: "remove srpm artifact from RPMS dir"
+  shell: rm /root/rpmbuild/RPMS/*.src.rpm

--- a/ansible/roles/machine_build/tasks/create_sources.yml
+++ b/ansible/roles/machine_build/tasks/create_sources.yml
@@ -1,0 +1,17 @@
+---
+- name: "link repo to temporary folder"
+  file:
+    src: /root/freeipa
+    dest: /tmp/freeipa-{{ build_version }}
+    state: link
+
+- name: "create directory for sources"
+  file:
+    path: /root/rpmbuild/SOURCES
+    state: directory
+
+- name: "pack the souces to tar.gz"
+  archive:
+    path: /tmp/freeipa-{{ build_version }}
+    dest: /root/rpmbuild/SOURCES/freeipa-{{ build_version }}.tar.gz
+    format: gz

--- a/ansible/roles/machine_build/tasks/create_spec.yml
+++ b/ansible/roles/machine_build/tasks/create_spec.yml
@@ -1,0 +1,21 @@
+---
+- name: "add autoreconf to spec file"
+  lineinfile:
+    path: /root/freeipa/freeipa.spec.in
+    insertafter: "^%setup"
+    line: autoreconf -if
+
+- name: "change version in spec file"
+  lineinfile:
+    path: /root/freeipa/freeipa.spec.in
+    regexp: "^Version:"
+    line: "Version:        {{ build_version }}"
+
+- name: "create directory for spec file"
+  file:
+    path: /root/rpmbuild/SPECS
+    state: directory
+
+- name: "copy spec to rpmbuild"
+  shell: cp /root/freeipa/freeipa.spec.in /root/rpmbuild/SPECS/freeipa.spec
+

--- a/ansible/roles/machine_build/tasks/generate_build_version.yml
+++ b/ansible/roles/machine_build/tasks/generate_build_version.yml
@@ -1,0 +1,36 @@
+---
+- name: "parse major vesion"
+  shell: |
+    grep '^define(IPA_VERSION_MAJOR' /root/freeipa/VERSION.m4 | \
+    sed 's/define(IPA_VERSION_MAJOR, \?//' | \
+    sed 's/)//'
+  register: major
+
+- name: "parse minor vesion"
+  shell: |
+    grep '^define(IPA_VERSION_MINOR' /root/freeipa/VERSION.m4 | \
+    sed 's/define(IPA_VERSION_MINOR, \?//' | \
+    sed 's/)//'
+  register: minor
+
+- name: "parse release vesion"
+  shell: |
+    grep '^define(IPA_VERSION_RELEASE' /root/freeipa/VERSION.m4 | \
+    sed 's/define(IPA_VERSION_RELEASE, \?//' | \
+    sed 's/)//'
+  register: release
+
+- name: "create timestamp"
+  shell: "date -u +'%Y%m%d%H%M%S'"
+  register: timestamp
+
+- name: "get git revision"
+  shell: "git rev-parse --short HEAD"
+  args:
+    chdir: /root/freeipa
+  register: revision
+
+- name: "create version"
+  set_fact:
+    build_version: "{{ major.stdout }}.{{ minor.stdout }}.{{ release.stdout }}.dev{{ timestamp.stdout }}+git{{ revision.stdout }}"
+

--- a/ansible/roles/machine_build/tasks/main.yml
+++ b/ansible/roles/machine_build/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- include: clone_git_repo.yml
+- include: generate_build_version.yml
+- include: create_spec.yml
+- include: create_sources.yml
+- include: create_rpms.yml

--- a/ansible/roles/machine_build_template/tasks/cleanup.yml
+++ b/ansible/roles/machine_build_template/tasks/cleanup.yml
@@ -1,0 +1,11 @@
+---
+- name: "remove git repository"
+  file:
+    path: /root/freeipa
+    state: absent
+
+- name: "remove build folder"
+  file:
+    path: /root/rpmbuild
+    state: absent
+

--- a/ansible/roles/machine_build_template/tasks/install_freeipa_builddeps.yml
+++ b/ansible/roles/machine_build_template/tasks/install_freeipa_builddeps.yml
@@ -1,0 +1,9 @@
+---
+- name: "clone git repo"
+  git:
+    repo: "{{ freeipa_git_repo }}"
+    dest: /root/freeipa
+    version: "{{ freeipa_git_branch }}"
+    depth: 1
+
+- name: "

--- a/ansible/roles/machine_build_template/tasks/install_packages.yml
+++ b/ansible/roles/machine_build_template/tasks/install_packages.yml
@@ -1,0 +1,9 @@
+---
+- name: "install packages for builder role"
+  dnf:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - mock
+    - git
+

--- a/ansible/roles/machine_build_template/tasks/main.yml
+++ b/ansible/roles/machine_build_template/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- include: install_packages.yml
+- include: setup_mock.yml
+- include: cleanup.yml
+
+

--- a/ansible/roles/machine_build_template/tasks/setup_mock.yml
+++ b/ansible/roles/machine_build_template/tasks/setup_mock.yml
@@ -1,0 +1,27 @@
+---
+- name: "set default mock config"
+  file:
+    src: "/etc/mock/{{ build_chroot }}.cfg"
+    dest: /etc/mock/default.cfg
+    state: link
+    force: yes
+
+- name: "enable copr repo for mock"
+  blockinfile:
+    block: |
+      [freeipa_copr]
+      name=Copr repo {{ freeipa_copr }}
+      baseurl=https://copr-be.cloud.fedoraproject.org/results/{{ freeipa_copr }}/fedora-$releasever-$basearch/
+      type=rpm-md
+      skip_if_unavailable=True
+      gpgcheck=1
+      gpgkey=https://copr-be.cloud.fedoraproject.org/results/{{ freeipa_copr }}/pubkey.gpg
+      repo_gpgcheck=0
+      enabled=1
+      enabled_metadata=1
+    dest: /etc/mock/default.cfg
+    insertbefore: '^\[fedora\]'
+
+# TODO: optimize mock
+# https://fedoraproject.org/wiki/Using_Mock_to_test_package_builds#Speeding_up
+

--- a/ansible/roles/machine_template/tasks/install_packages.yml
+++ b/ansible/roles/machine_template/tasks/install_packages.yml
@@ -5,7 +5,7 @@
     state: latest
 
 - name: "install freeipa rpms with dependencies"
-  shell: "dnf install -y /vagrant/rpms/*.rpm"
+  shell: "dnf install -y /root/rpmbuild/RPMS/*.rpm"
 
 - name: "remove freeipa packages while keeping dependencies"
   shell: "rpm -e --nodeps '{{ item }}'"

--- a/create-template-box
+++ b/create-template-box
@@ -4,18 +4,6 @@
 chmod 600 keys/vagrant
 chmod 600 keys/freeipa_pr_ci_insecure
 
-# Show contents of rpms directory
-ls rpms
-
-# Prompt for confirmation
-echo -n "Proceed with these packages? [y/N]: "
-read answer
-if [[ ! $answer =~ ^[Yy]$ ]]
-then
-    # handle exits from shell or function but don't exit interactive shell
-    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
-fi
-
 # Run playbook to create box
 ansible-playbook -v -K -i ansible/hosts/runner_localhost \
   ansible/create_template_box.yml

--- a/rpms/README.md
+++ b/rpms/README.md
@@ -1,3 +1,0 @@
-This directory is used when generating templates. Place the current build's
-rpms in this directory to install their runtime dependencies in the template.
-


### PR DESCRIPTION
Box template is now generated with mock environment with the
necessary build dependencies. An ansible playbook can be used
to build rpms from git sources.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>