### PR TITLE
template: add workaround for gssproxy nfs-utils issue

### DIFF
--- a/ansible/roles/machine/workarounds/tasks/gssproxy_nfsutils.yml
+++ b/ansible/roles/machine/workarounds/tasks/gssproxy_nfsutils.yml
@@ -1,0 +1,24 @@
+---
+# https://bugzilla.redhat.com/show_bug.cgi?id=1452881
+#
+# If nfs-utils is installed and nfs in not started,
+# ipa-server-install would fail with:
+#
+#     [11/22]: configuring Gssproxy
+#
+# Command '/bin/systemctl restart gssproxy.service' returned non-zero exit status 1
+#
+# GSS-Proxy is not supported by this kernel since file /proc/net/rpc/use-gss-proxy could not be found: 2 (No such file or directory)
+#
+
+- name: "check if nfs-utils is installed"
+  shell: rpm -q nfs-utils
+  register: rpm_check
+
+- name: "start&enable nfs service to avoid gssproxy issue"
+  service:
+    name: nfs
+    enabled: yes
+    state: started
+  when: rpm_check.rc == 0
+

--- a/ansible/roles/machine/workarounds/tasks/main.yml
+++ b/ansible/roles/machine/workarounds/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 - include: create_custodia_user.yml
 - include: vagrant_systemctl_no_pager.yml
+- include: gssproxy_nfsutils.yml
 


### PR DESCRIPTION
systemctl restart gssproxy would fail during ipa-server-install,
becase nfs-utils was installed, but nfs wasn't started.

Remove once https://bugzilla.redhat.com/show_bug.cgi?id=1452881
is fixed.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>