### PR TITLE
github: Change tasks file format

### DIFF
--- a/github/prci_github/internals.py
+++ b/github/prci_github/internals.py
@@ -218,8 +218,8 @@ class Tasks(collections.Set, collections.Mapping):
             try:
                 self.tasks_conf = yaml.load(
                                     base64.b64decode(tasks_file.content)
-                                  )
-            except (yaml.error.YAMLError, TypeError) as err:
+                                  )['jobs']
+            except (yaml.error.YAMLError, TypeError, KeyError) as err:
                 logger.warning('Failed to decode tasks file in PR %d: %s',
                                pull.pull.number, err)
 


### PR DESCRIPTION
For easier future changes all jobs are inside 'jobs' key.