### PR TITLE
runner: link template image from vagrant to libvirt

### DIFF
--- a/ansible/roles/runner/files/libvirt_default_pool.xml
+++ b/ansible/roles/runner/files/libvirt_default_pool.xml
@@ -1,0 +1,6 @@
+<pool type='dir'>
+  <name>default</name>
+  <target>
+    <path>/var/lib/libvirt/images</path>
+  </target>
+</pool>

--- a/ansible/roles/runner/tasks/create_libvirt_pool.yml
+++ b/ansible/roles/runner/tasks/create_libvirt_pool.yml
@@ -1,0 +1,15 @@
+---
+- name: check if default pool exists in libvirt
+  shell: virsh vol-list default
+  register: virsh_res
+  failed_when: false
+
+- name: create default pool in libvirt
+  block:
+    - copy:
+        src: libvirt_default_pool.xml
+        dest: /tmp/libvirt_default_pool.xml
+    - shell: virsh pool-define /tmp/libvirt_default_pool.xml
+    - shell: virsh pool-start default
+    - shell: virsh pool-autostart default
+  when: virsh_res.rc != 0

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -6,6 +6,7 @@
   when: enable_nested_virt
   tags: nested_virt
 - include: setup.yml
+- include: create_libvirt_pool.yml
 - include: deploy_pr_ci.yml
 - include: deploy_prci_configuration.yml
   when: deploy_prci_configuration

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -19,6 +19,8 @@ RUNNER_LOG = 'runner.log'
 FREEIPA_PRCI_REPOFILE = 'freeipa-prci.repo'
 ANSIBLE_VARS_TEMPLATE = '{action_name}.vars.yml'
 VAGRANTFILE_TEMPLATE = 'Vagrantfile.{action_name}'
+VAGRANT_IMAGE_PATH = '/root/.vagrant.d/boxes/{name}/{version}/{provider}/box.img'
+LIBVIRT_IMAGE_PATH = '/var/lib/libvirt/images/{libvirt_name}_{version}.img'
 
 ANSIBLE_CFG_FILE = os.path.join(TEMPLATES_DIR, 'ansible.cfg')
 

--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,2 +1,0 @@
-pyvagrantfile>=0.5.11
-jinja2

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -14,7 +14,7 @@ from .vagrant import with_vagrant
 
 class JobTask(FallibleTask):
     def __init__(self, template, no_destroy=False, publish_artifacts=True,
-                 **kwargs):
+                 link_image=True, **kwargs):
         super(JobTask, self).__init__(**kwargs)
         self.template_name = template['name']
         self.template_version = template['version']
@@ -25,6 +25,7 @@ class JobTask(FallibleTask):
         self.returncode = 1
         self.no_destroy = no_destroy
         self.description = '<no description>'
+        self.link_image = link_image
 
     @property
     def data_dir(self):


### PR DESCRIPTION
By default, libvirt copies the template image from vagrant to its local
storage pool. To save storage space on runners, this template image is
linked from the vagrant box directory to libvirt storage.

This option should be turned off for local execution, because it requires
correct permissions for the .vagrant.d directory.

Signed-off-by: Tomas Krizek <tomas.krizek@mailbox.org>