### PR TITLE
Allow creation of F26 template

### DIFF
--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -1,14 +1,22 @@
 ---
-- hosts: runner
+- hosts: localhost
   name: prepare vagrant box
   become_user: root
+  vars:
+    # Fedora 25
+    # base_box_name: f25
+    # base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box
+
+    # Fedora 26
+    base_box_name: f26
+    base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-26-1.5.x86_64.vagrant-libvirt.box
   vars_prompt:
     - name: git_branch
       prompt: "git branch (e.g. master)"
       private: false
   pre_tasks:
     - set_fact:
-        template_box_name: "ci-{{ git_branch }}-f25"
+        template_box_name: "ci-{{ git_branch }}-{{ base_box_name }}"
   roles:
     - box/prepare
 
@@ -23,6 +31,12 @@
 
 - hosts: image_box
   name: modify vagrant box template
+  vars:
+    # Fedora 25
+    # build_chroot: fedora-25-x86_64
+
+    # Fedora 26
+    build_chroot: fedora-26-x86_64
   vars_prompt:
     - name: git_branch
       prompt: "git branch (e.g. master)"
@@ -35,7 +49,7 @@
       git_version: "{{ git_branch }}"
     - role: machine
 
-- hosts: runner
+- hosts: localhost
   name: package template box
   become_user: root
   roles:

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -1,3 +1,2 @@
 ---
 git_repo: https://github.com/freeipa/freeipa.git
-build_chroot: fedora-25-x86_64

--- a/ansible/roles/box/prepare/defaults/main.yml
+++ b/ansible/roles/box/prepare/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box
-base_box_name: f25
 template_box_dir: "/tmp/{{ template_box_name }}"

--- a/ansible/roles/machine/cleanup/tasks/clean_hostname.yml
+++ b/ansible/roles/machine/cleanup/tasks/clean_hostname.yml
@@ -8,5 +8,5 @@
     regexp: "HOSTNAME"
     state: absent
 
-- name: regenerate initrd to remove hardcoded hostname
-  command: /usr/bin/dracut --regenerate-all --force
+# - name: regenerate initrd to remove hardcoded hostname
+#   command: /usr/bin/dracut --regenerate-all --force


### PR DESCRIPTION
A more user-friendly way to switch between Fedora templates should be considered in the future. As of now, the appropriate sections of `create_template_box.yml` have to be (un)commented.