### PR TITLE
vagrant: remove bridged network

### DIFF
--- a/templates/Vagrantfile.build
+++ b/templates/Vagrantfile.build
@@ -23,12 +23,6 @@ Vagrant.configure(2) do |config|
 
         # Recommended for remote NFS storage
         domain.volume_cache = "none"
-
-        # Add connection to public network
-        override.vm.network "public_network",
-            dev: "virbr0",
-            mode: "bridge",
-            type: "bridge"
     end
 
     config.vm.define "builder"  do |builder|

--- a/templates/Vagrantfile.run_pytest
+++ b/templates/Vagrantfile.run_pytest
@@ -29,12 +29,6 @@ Vagrant.configure(2) do |config|
 
         # Recommended for remote NFS storage
         domain.volume_cache = "none"
-
-        # Add connection to public network
-        override.vm.network "public_network",
-            dev: "virbr0",
-            mode: "bridge",
-            type: "bridge"
     end
 
     config.vm.define "controller" , primary: true do |controller|


### PR DESCRIPTION
Guest VMs aren't accessed from the outside network and bridged
mode caused network slowdowns combined with nested virtualization.
NAT mode is used by default, which enables both network access to internet
from VM and network access between the VMs themselves.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>