### PR TITLE
beaker: use one partition for root

### DIFF
--- a/templates/beaker-min.xml
+++ b/templates/beaker-min.xml
@@ -29,8 +29,7 @@
          </and>
        </hostRequires>
       <partitions>
-        <partition type="part" name="/var/lib" size="20" fs="ext4"/>
-        <partition type="part" name="/root/" size="20" fs="ext4"/>
+        <partition type="part" name="/" size="50" fs="ext4"/>
       </partitions>
       <task name="/distribution/install" role="STANDALONE"/>
       <task name="/distribution/reservesys" role="STANDALONE">


### PR DESCRIPTION
/root/.vagrant.d and /var/lib/libvirt have to be on the same
partition to take advantage of the hard links to conserve
storage space.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>