### PR TITLE
README: add partitioning prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ contributors, you can check out this [video](https://vimeo.com/228077191).
   configuration including hostname and networking should persist after reboot.
 - **Minimum specs**: 4 vCPUs, 8 GB RAM, 30 GB disk.
 - **Operating system**: currently, only Fedora is supported.
+- **Partitioning**: `/var/lib/libvirt/images` and `/root/.vagrant.d/` have to
+  be on the *same* partition.
 
 #### Other
 


### PR DESCRIPTION
In order to take advantage of hard links to conserve storage space,
libvirt and vagrant image directory have to be on the same partition.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>