### PR TITLE
github: rate-limit API calls

### DIFF
--- a/github/prci_github/adapter.py
+++ b/github/prci_github/adapter.py
@@ -35,6 +35,9 @@ class GitHubAdapter(CacheControlAdapter):
         for try_counter in range(self.tries):
             logger.debug('%s: try %d', self.__class__.__name__, try_counter)
 
+            # Rate-limit requests to avoid hitting GitHub API abuse limit
+            time.sleep(0.5)
+
             try:
                 response = super(GitHubAdapter, self).send(
                     request, *args, **kwargs)


### PR DESCRIPTION
To avoid triggering GitHub's abuse policy, slow down API calls.
Using up to 1500 req/minute seems to work fine, so this should
allow scaling up to 25 runners.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>