### PR TITLE
vm provisioning: use dns server provided by vagrant

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
-- name: create test config file
-  template:
-    src: ipa-test-config.yaml
-    dest: /vagrant/ipa-test-config.yaml
+- block:
+    - name: get DNS server from resolv.conf
+      shell: awk '$1 == "nameserver" {print $2; exit}' /etc/resolv.conf
+      register: dns_server
+
+    - name: create test config file
+      template:
+        src: ipa-test-config.yaml
+        dest: /vagrant/ipa-test-config.yaml
   when: inventory_hostname == 'controller'
 
 - name: add PR build repository

--- a/ansible/roles/machine/provision/templates/ipa-test-config.yaml
+++ b/ansible/roles/machine/provision/templates/ipa-test-config.yaml
@@ -5,7 +5,7 @@ admin_password: Secret.123
 debug: false
 dirman_dn: cn=Directory Manager
 dirman_password: Secret.123
-dns_forwarder: 10.34.78.1
+dns_forwarder: {{ dns_server.stdout }}
 domains:
 - hosts:
 {% for host in groups['all'] %}


### PR DESCRIPTION
Instead of relying on our internal DNS infrastructure, use the DNS
server from vagrant, which forwards the requests to hosts' DNS server.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>