### PR TITLE
tempalte: add python3-paramiko

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -36,6 +36,7 @@
     - PyYAML  # ipa-vagrant-ci dependency
     - vim
     - NetworkManager
+    - python3-paramiko
 
 - name: install pip dependencies
   pip:


### PR DESCRIPTION
This package is required for Python3 testing.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>