### PR TITLE
Adding dependencies to run ipa-tests with python3

### DIFF
--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
 selinux_mode: permissive
 copr_repo: "@freeipa/freeipa-master"
-
+python_packages_to_install:
+  - pytest-html
+  - paramiko==2.2.1
+# It's necessary to use paramiko v2.2.1 due to issues
+# with gssapi (github.com/paramiko/paramiko/issues/1069)

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -36,12 +36,16 @@
     - PyYAML  # ipa-vagrant-ci dependency
     - vim
     - NetworkManager
-    - python3-paramiko
 
-- name: install pip dependencies
+- name: install py3 pip dependencies
   pip:
-    name: pytest-html
-    state: latest
+    executable: pip3
+    name: "{{ python_packages_to_install | join(' ') }}"
+
+- name: install py2 pip dependencies
+  pip:
+    executable: pip
+    name: "{{ python_packages_to_install | join(' ') }}"
 
 - name: disable distro repositories
   shell: "dnf config-manager --set-disabled {{ item }}"


### PR DESCRIPTION
It's necessary to use paramiko v2.2.1 due to issues with gssapi (https://github.com/paramiko/paramiko/issues/1069)