### PR TITLE
runner: don't wait for reboot after deployment

### DIFF
--- a/ansible/roles/runner/handlers/main.yml
+++ b/ansible/roles/runner/handlers/main.yml
@@ -10,11 +10,8 @@
   poll: 0
   ignore_errors: true
   notify:
-    - wait for machine
+    - reboot_message
 
-- name: wait for machine
-  local_action: wait_for
-    host="{{ inventory_hostname }}"
-    port=22
-    delay=10
-    timeout=120
+- name: reboot_message
+  debug:
+    msg: "System {{ inventory_hostname }} is rebooting."


### PR DESCRIPTION
Often the 2 minute timeout wasn't enough for the machine to come back
and the playbook would seemingly fail on the last step. Even though the
error was harmless, it could confuse users.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>