### PR TITLE
ansible: make callback plugin forward compatible

### DIFF
--- a/ansible/callback_plugins/human_log.py
+++ b/ansible/callback_plugins/human_log.py
@@ -26,12 +26,14 @@ try:
 except ImportError:
     import json
 
+from ansible.plugins.callback import CallbackBase
+
 # Fields to reformat output for
 FIELDS = ['cmd', 'command', 'start', 'end', 'delta', 'msg', 'stdout',
           'stderr', 'results']
 
 
-class CallbackModule(object):
+class CallbackModule(CallbackBase):
 
     """
     Ansible callback plugin for human-readable result logging


### PR DESCRIPTION
Ansible 2.4.0 made some backward incompatible changes which prevented
human_log.py to work properly. This ensures it works with both <2.4 and
>= 2.4 Ansible version.

Issue in Ansible: https://github.com/ansible/ansible/issues/30597

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>