### PR TITLE
Adding the tox tests on PR CI infraestructure

### DIFF
--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -4,5 +4,6 @@ copr_repo: "@freeipa/freeipa-master"
 python_packages_to_install:
   - pytest-html
   - paramiko==2.2.1
+  - tox
 # It's necessary to use paramiko v2.2.1 due to issues
 # with gssapi (github.com/paramiko/paramiko/issues/1069)

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -37,6 +37,12 @@
     - vim
     - NetworkManager
 
+    # the packages below are used to run the tox tests
+    - autoconf
+    - gettext-devel
+    - automake
+    - libtool
+
 - name: install py3 pip dependencies
   pip:
     executable: pip3

--- a/ansible/tox_provision.yml
+++ b/ansible/tox_provision.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  name: 'Tox tests provisioning'
+  tasks:
+
+    - name: 'clone freeipa'
+      git:
+        repo: "{{ git_repo }}"
+        dest: /root/freeipa
+        version: "{{ git_version | default('master') }}"
+        force: yes
+
+    - name: 'enable repositories'
+      shell: dnf builddep -y --enablerepo=fedora,updates --spec freeipa/freeipa.spec.in
+
+    - name: 'clean git'
+      shell: cd freeipa; git clean -dfx

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,2 +1,2 @@
 from .common import logging_init_stream_handler, TimeoutException
-from .tasks import Build, RunPytest
+from .tasks import Build, RunPytest, ToxTests

--- a/templates/Vagrantfile.tox
+++ b/templates/Vagrantfile.tox
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+Vagrant.configure(2) do |config|
+
+    config.ssh.username = "root"
+
+    config.vm.synced_folder "./", "/vagrant",
+        type: "nfs",
+        nfs_udp: false
+
+    config.vm.box = "{{ vagrant_template_name }}"
+    config.vm.box_version = "{{ vagrant_template_version }}"
+
+    config.vm.provider "libvirt" do |domain, override|
+        # Nested virtualization options
+        domain.nested = true
+        domain.cpu_mode = "host-passthrough"
+
+        # Disable graphics
+        domain.graphics_type = "none"
+
+        # Recommended for remote NFS storage
+        domain.volume_cache = "none"
+    end
+
+    config.vm.define "toxtests"  do |builder|
+        builder.vm.provider "libvirt" do |domain,override|
+            domain.cpus = 1
+            domain.memory = 1024
+        end
+    end
+
+    config.vm.provision :ansible do |ansible|
+        ansible.limit = "all"
+        ansible.playbook = "../../ansible/tox_provision.yml"
+    end
+
+end


### PR DESCRIPTION
A simple Vagranfile was created to be used to run the tox tests.
A new class ToxTests was added and can be used in .freeipa-pr-ci.yaml
in freeipa. Also, news packages were added in the creation of the
template in order to have they available to run the tox tests.

I have a [PR on my freeipa fork](https://github.com/felipevolpone/freeipa/pull/13) that shows the result of the run. You can also [check here](https://fedorapeople.org/groups/freeipa/prci/jobs/68cb76b8-b346-11e7-9532-001a4a23156e/). 

After ACKing this PR, a new vagrant template is needed.

