### PR TITLE
Adding installed packages list to a separate file

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -34,13 +34,13 @@
         - freeipa-*
         - python*-ipatests
 
-- name: get all packages
-  shell: rpm -qa
-  register: packages
+- name: create directory to save installed packages logs
+  file:
+    path: /vagrant/installed_packages/
+    state: directory
 
-- name: display installed packages
-  debug:
-    var: packages.stdout
+- name: get all packages
+  shell: rpm -qa > /vagrant/installed_packages/installed_packages_{{inventory_hostname}}.log
 
 - name: create hosts file from template
   template:


### PR DESCRIPTION
With this change, the installed packages will be listed in the
/vagrant/installed_packages.log.gz files. After sending the
stdout to the file, we have a task that collects the files
in the shared directory. This is done via the shared directory
inside the vagrant VMs in `/vagrant`.
For more info about it, check `tasks/remote_storage.py::GzipLogFiles`

Fixes #106