### PR TITLE
Fixing the ipa-test-config.yaml in order to run external CA tests

### DIFF
--- a/ansible/roles/machine/provision/templates/ipa-test-config.yaml
+++ b/ansible/roles/machine/provision/templates/ipa-test-config.yaml
@@ -29,4 +29,4 @@ domains:
 nis_domain: ipatest
 ntp_server: 1.pool.ntp.org
 root_ssh_key_filename: /root/.ssh/freeipa_pr_ci_insecure
-test_dir: ../../ipatests
+test_dir: /ipatests


### PR DESCRIPTION
To run the external CA tests, we have to provide the absolute path of the certs.