### PR TITLE
Revert "templates: increase CPUs on master to 2"

### DIFF
--- a/templates/Vagrantfile.run_pytest
+++ b/templates/Vagrantfile.run_pytest
@@ -47,12 +47,6 @@ Vagrant.configure(2) do |config|
 
 
     config.vm.define "master"  do |master|
-        # FIXME: This is strictly a temporary change for debugging purposes
-        # https://pagure.io/freeipa/issue/7165
-        # Added by mreznik's request
-        master.vm.provider "libvirt" do |domain,override|
-            domain.cpus = 2
-        end
     end
 
 


### PR DESCRIPTION
This reverts commit ddeb09a72bd50188cf1ceffe382e595480481a8f.
It was introduced as a temporary change for testing/debugging.