### PR TITLE
Force ipa-run-tests to use python 2

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -225,7 +225,7 @@ class RunPytest(JobTask):
         self.execute_subtask(
             PopenTask(['vagrant', 'ssh', '-c', (
                 'IPATEST_YAML_CONFIG=/vagrant/ipa-test-config.yaml '
-                'ipa-run-tests {test_suite} '
+                'ipa-run-tests-2 {test_suite} '
                 '--verbose --logging-level=debug --logfile-dir=/vagrant/ '
                 '--html=/vagrant/report.html'
                 ).format(test_suite=self.test_suite)],


### PR DESCRIPTION
Since commit d39456a882efacbfefcc1f987ebf89ceeb761f61 in freeIPA, if freeIPA
is built using python3, ipa-run-tests will use python3 by default.
However, paramiko it's showing problems to collect logs from the hosts when using py3.

This is just a hotfix to have the logs back as soon as possible.