### PR TITLE
Enabling multiple topologies

### DIFF
--- a/github/prci.py
+++ b/github/prci.py
@@ -16,8 +16,7 @@ import github3
 import redis
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
-from prci_github import (TaskQueue, AbstractJob, JobResult,
-                         InsufficientResources)
+from prci_github import TaskQueue, AbstractJob, JobResult
 from prci_github.adapter import GitHubAdapter
 
 
@@ -26,8 +25,7 @@ ERROR_BACKOFF_TIME = 600
 REBOOT_DELAY = 3600 * 3
 REBOOT_TIME_FILE = '/root/next_reboot'
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-TASK_MIN_CPU = 2
-TASK_MIN_MEM = 900
+
 
 class ExitHandler(object):
     done = False
@@ -277,14 +275,6 @@ def main():
                 task = next(task_queue)
             except StopIteration:
                 time.sleep(no_task_backoff_time)
-                continue
-
-            try:
-                task_queue.check_resources(task)
-            except InsufficientResources:
-                # if the runner does not has enough resources
-                # it's necessary to drop the assign status in the task
-                task.drop()
                 continue
 
             handler.register_task(task)

--- a/github/prci_github/__init__.py
+++ b/github/prci_github/__init__.py
@@ -1,3 +1,5 @@
-from .internals import TaskQueue, AbstractJob, TaskAlreadyTaken, JobResult
+from .internals import (TaskQueue, AbstractJob, TaskAlreadyTaken,
+                        JobResult, InsufficientResources)
 
-__all__ = ['TaskQueue', 'AbstractJob', 'TaskAlreadyTaken', 'JobResult']
+__all__ = ['TaskQueue', 'AbstractJob', 'TaskAlreadyTaken', 'JobResult',
+           'InsufficientResources']

--- a/github/prci_github/internals.py
+++ b/github/prci_github/internals.py
@@ -378,7 +378,6 @@ class TaskQueue(collections.Iterator):
         self.runner_id = runner_id
         self.total_cpus = psutil.cpu_count()
         self.total_memory = psutil.virtual_memory().total / float(2 ** 20)
-        self.done = False
 
     def check_resources(self, task):
         # if task don't specify resource requirements behave like it needs
@@ -387,7 +386,6 @@ class TaskQueue(collections.Iterator):
         task_mem = task.resources.get('memory', self.total_memory)
 
         if task_cpu <= self.total_cpus and task_mem <= self.total_memory:
-            task_key = (task.pull.pull.head.sha, task.name,)
             logger.debug(
                 'TaskQueue: resource check ok PR#%d/%s (%d CPUs, %d MiB RAM)',
                 task.pull.pull.number, task.name, task_cpu, task_mem)

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -18,7 +18,7 @@ UUID_RE = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 RUNNER_LOG = 'runner.log'
 FREEIPA_PRCI_REPOFILE = 'freeipa-prci.repo'
 ANSIBLE_VARS_TEMPLATE = '{action_name}.vars.yml'
-VAGRANTFILE_TEMPLATE = 'Vagrantfile.{action_name}'
+VAGRANTFILE_TEMPLATE = os.path.join('vagrantfiles', 'Vagrantfile.{vagrantfile_name}')
 VAGRANT_IMAGE_PATH = '/root/.vagrant.d/boxes/{name}/{version}/{provider}/box.img'
 LIBVIRT_IMAGE_PATH = '/var/lib/libvirt/images/{libvirt_name}_{version}.img'
 
@@ -27,6 +27,9 @@ ANSIBLE_CFG_FILE = os.path.join(TEMPLATES_DIR, 'ansible.cfg')
 POPEN_TERM_TIMEOUT = 10
 BUILD_TIMEOUT = 30*60
 RUN_PYTEST_TIMEOUT = 90*60
+
+# Topologies
+DEFAULT_TOPOLOGY = 'master_1repl'
 
 # Playbooks
 ANSIBLE_PLAYBOOK_DIR = os.path.join(BASE_DIR, 'ansible')

--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -27,8 +27,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "builder"  do |builder|
         builder.vm.provider "libvirt" do |domain,override|
-            domain.cpus = 4
-            domain.memory = 4096
+            domain.cpus = 2
+            domain.memory = 3800
         end
 
         builder.vm.provision "ansible" do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+Vagrant.configure(2) do |config|
+
+    config.ssh.username = "root"
+
+    config.vm.synced_folder "./", "/vagrant",
+        type: "nfs",
+        nfs_udp: false
+
+    config.vm.box = "{{ vagrant_template_name }}"
+    config.vm.box_version = "{{ vagrant_template_version }}"
+
+    config.vm.provider "libvirt" do |domain, override|
+        # Defaults for masters and replica
+        # WARNING: Do not overcommit CPUs, it causes issues during
+        # provisioning, when RPMs are installed
+        domain.cpus = 1
+        domain.memory = 2400
+
+        # Nested virtualization options
+        domain.nested = true
+        domain.cpu_mode = "host-passthrough"
+
+        # Disable graphics
+        domain.graphics_type = "none"
+
+        # Recommended for remote NFS storage
+        domain.volume_cache = "none"
+    end
+
+    config.vm.define "controller" , primary: true do |controller|
+        controller.vm.provider "libvirt" do |domain,override|
+            # Less resources needed for controller
+            domain.memory = 950
+        end
+
+        controller.vm.provision :ansible do |ansible|
+            # Disable default limit to connect to all the machines
+            ansible.limit = "all"
+            ansible.playbook = "../../ansible/provision.yml"
+            ansible.extra_vars = "vars.yml"
+        end
+    end
+
+
+    config.vm.define "master"  do |master|
+        # FIXME: This is strictly a temporary change for debugging purposes
+        # https://pagure.io/freeipa/issue/7165
+        # Added by mreznik's request
+        master.vm.provider "libvirt" do |domain,override|
+            domain.cpus = 2
+        end
+    end
+
+
+    config.vm.define "replica0"  do |replica0|
+    end
+
+end

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -1,8 +1,5 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-#
 
-Vagrant.configure(2) do |config|
+ |config|
 
     config.ssh.username = "root"
 
@@ -18,7 +15,7 @@ Vagrant.configure(2) do |config|
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
         domain.cpus = 1
-        domain.memory = 2560
+        domain.memory = 2400
 
         # Nested virtualization options
         domain.nested = true
@@ -34,7 +31,7 @@ Vagrant.configure(2) do |config|
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
             # Less resources needed for controller
-            domain.memory = 1024
+            domain.memory = 950
         end
 
         controller.vm.provision :ansible do |ansible|
@@ -45,18 +42,16 @@ Vagrant.configure(2) do |config|
         end
     end
 
-
     config.vm.define "master"  do |master|
-        # FIXME: This is strictly a temporary change for debugging purposes
-        # https://pagure.io/freeipa/issue/7165
-        # Added by mreznik's request
-        master.vm.provider "libvirt" do |domain,override|
-            domain.cpus = 2
-        end
     end
 
-
     config.vm.define "replica0"  do |replica0|
+    end
+
+    config.vm.define "client0"  do |client0|
+        client0.vm.provider "libvirt" do |domain,override|
+            domain.memory = 950
+        end
     end
 
 end


### PR DESCRIPTION
In order to have more tests running in upstream PR CI
infrastructure, we need to support multiple topologies:
multiple master, replicas and clients. This PR address this.

To know the resources that a given task should have to
run it, the freeipa/freeipa/.freeipa-pr-ci.yml file will
declare how much RAM and CPUs are needed. Using this syntax:

```
topologies:
  master_1repl: &master_1repl
    name: master_1repl
    cpu: 2
    memory: 4098
  master_1repl_1client: &master_1repl_1client
    name: master_1repl_1client
    cpu: 6
    memory: 6144
```

After declaring the topologies, the tasks will be able
to use it with this syntax:

```
fedora-26/simple_replication:
    ...
    job:
      class: RunPytest
      args:
        ...
        topology: *master_1repl
```

Is IMPORTANT to say that, the name of the topology
must match with the name of a Vagrantfile inside the
templates/vagrantfiles dir. So, if a topology is added to
the .freeipa-pr-ci.yml file, a corresponding Vagrantfile
must be added to the freeipa-pr-ci project as well.

The Task class will read the config file and the Scheduler
will deal with it, to know if the runner is able to run
that task.

Fixes #70