### PR TITLE
Limiting the systemd journal size

### DIFF
--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -9,3 +9,4 @@ pr_ci_repo_owner: freeipa
 pr_ci_repo: "https://github.com/{{ pr_ci_repo_owner }}/freeipa-pr-ci"
 pr_ci_repo_branch: master
 no_task_backoff_time: 300
+limit_size_systemd_journal: 300M

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -67,3 +67,10 @@
     name: redis
     enabled: true
     state: started
+
+- name: configure size of systemd journal
+  lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#?SystemMaxFileSize'
+    line: 'SystemMaxFileSize={{ limit_size_systemd_journal }}'
+    state: present


### PR DESCRIPTION
It's possible to change the value of 300M in the `defaults/main.yml` file.

Fixes #53 