### PR TITLE
ansible: use import_tasks instead of include

### DIFF
--- a/ansible/roles/box/prepare/tasks/main.yml
+++ b/ansible/roles/box/prepare/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: cleanup.yml
+- import_tasks: cleanup.yml
   tags: cleanup
 
 - name: create folder for image

--- a/ansible/roles/builder/build/tasks/main.yml
+++ b/ansible/roles/builder/build/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: prepare.yml
-- include: clone_git_repo.yml
-- include: check_4_5_build_system.yml
-- include: generate_build_version.yml
-- include: create_spec.yml
-- include: create_sources.yml
-- include: create_rpms.yml
+- import_tasks: prepare.yml
+- import_tasks: clone_git_repo.yml
+- import_tasks: check_4_5_build_system.yml
+- import_tasks: generate_build_version.yml
+- import_tasks: create_spec.yml
+- import_tasks: create_sources.yml
+- import_tasks: create_rpms.yml
 

--- a/ansible/roles/builder/cleanup/tasks/main.yml
+++ b/ansible/roles/builder/cleanup/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: remove_directories.yml
+- import_tasks: remove_directories.yml
 

--- a/ansible/roles/builder/prepare/tasks/main.yml
+++ b/ansible/roles/builder/prepare/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: install_packages.yml
-- include: setup_mock.yml
+- import_tasks: install_packages.yml
+- import_tasks: setup_mock.yml
 

--- a/ansible/roles/machine/cleanup/tasks/main.yml
+++ b/ansible/roles/machine/cleanup/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: clean_caches.yml
-- include: clean_hostname.yml
-- include: clean_dhcp_state.yml
-- include: clean_mac_addresses.yml
-- include: clean_logs.yml
-- include: clean_history.yml
+- import_tasks: clean_caches.yml
+- import_tasks: clean_hostname.yml
+- import_tasks: clean_dhcp_state.yml
+- import_tasks: clean_mac_addresses.yml
+- import_tasks: clean_logs.yml
+- import_tasks: clean_history.yml
 

--- a/ansible/roles/machine/setup/tasks/main.yml
+++ b/ansible/roles/machine/setup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: configuration.yml
-- include: setup_rng.yml
-- include: install_packages.yml
-- include: manage_ssh_keys.yml
+- import_tasks: configuration.yml
+- import_tasks: setup_rng.yml
+- import_tasks: install_packages.yml
+- import_tasks: manage_ssh_keys.yml
 

--- a/ansible/roles/machine/workarounds/tasks/main.yml
+++ b/ansible/roles/machine/workarounds/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: create_custodia_user.yml
-- include: vagrant_systemctl_no_pager.yml
+- import_tasks: create_custodia_user.yml
+- import_tasks: vagrant_systemctl_no_pager.yml
 

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- include: manage_ssh_keys.yml
+- import_tasks: manage_ssh_keys.yml
   when: deploy_ssh_key
   tags: fedorapeople
-- include: enable_nested_virt.yml
+- import_tasks: enable_nested_virt.yml
   when: enable_nested_virt
   tags: nested_virt
-- include: setup.yml
-- include: create_libvirt_pool.yml
-- include: deploy_pr_ci.yml
+- import_tasks: setup.yml
+- import_tasks: create_libvirt_pool.yml
+- import_tasks: deploy_pr_ci.yml


### PR DESCRIPTION
include is deprecated in Anible 2.3.

Fixes: #119
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>