### PR TITLE
Migrate to F27 box

### DIFF
--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -8,8 +8,12 @@
     # base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box
 
     # Fedora 26
-    base_box_name: f26
-    base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-26-1.5.x86_64.vagrant-libvirt.box
+    # base_box_name: f26
+    # base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-26-1.5.x86_64.vagrant-libvirt.box
+
+    # Fedora 27
+    base_box_name: f27
+    base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-27-1.6.x86_64.vagrant-libvirt.box
   vars_prompt:
     - name: git_branch
       prompt: "git branch (e.g. master)"
@@ -36,7 +40,10 @@
     # build_chroot: fedora-25-x86_64
 
     # Fedora 26
-    build_chroot: fedora-26-x86_64
+    # build_chroot: fedora-26-x86_64
+
+    # Fedora 27
+    build_chroot: fedora-27-x86_64
   vars_prompt:
     - name: git_branch
       prompt: "git branch (e.g. master)"


### PR DESCRIPTION
Generate F27 box based on official F27 vagrant-libvirt image.

Use https://github.com/abbra/freeipa/pull/6/commits/508f123b25fb25e3b69847a69ce0a5547731f469 against freeIPA to introduce F27 box there.