### PR TITLE
VM provisioning: add option to update packages

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -15,6 +15,12 @@
     dest: /etc/yum.repos.d/
     url: "{{ repofile_url }}"
 
+- name: update packages
+  dnf:
+    name: '*'
+    state: latest
+  when: update_packages is defined and update_packages
+
 - name: install freeipa packages
   block:
     - dnf:

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -189,10 +189,12 @@ class RunPytest(JobTask):
     action_name = 'run_pytest'
 
     def __init__(self, template, build_url, test_suite, topology=None,
-                 timeout=constants.RUN_PYTEST_TIMEOUT, **kwargs):
+                 timeout=constants.RUN_PYTEST_TIMEOUT, update_packages=False,
+                 **kwargs):
         super(RunPytest, self).__init__(template, timeout=timeout, **kwargs)
         self.build_url = build_url + '/'
         self.test_suite = test_suite
+        self.update_packages = update_packages
 
         if not topology:
             topology = {'name': constants.DEFAULT_TOPOLOGY}
@@ -214,7 +216,8 @@ class RunPytest(JobTask):
                     action_name=self.action_name),
                 os.path.join(self.data_dir, 'vars.yml'),
                 dict(repofile_url=urllib.parse.urljoin(
-                        self.build_url, 'rpms/freeipa-prci.repo')))
+                        self.build_url, 'rpms/freeipa-prci.repo'),
+                     update_packages=self.update_packages))
         except (OSError, IOError) as exc:
             msg = "Failed to prepare test config files"
             logging.debug(exc, exc_info=True)

--- a/templates/run_pytest.vars.yml
+++ b/templates/run_pytest.vars.yml
@@ -1,2 +1,3 @@
 ---
 repofile_url: {{ repofile_url }}
+update_packages: {{ update_packages }}


### PR DESCRIPTION
Enable a package update during VM provisioning in RunPytest job.

Related #109
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>