### PR TITLE
VM provisioning: remove repo fallback

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -16,23 +16,12 @@
     url: "{{ repofile_url }}"
 
 - name: install freeipa packages
-  block:
-    - dnf:
-        name: "{{ item }}"
-        state: latest
-      with_items:
-        - freeipa-*
-        - python*-ipatests
-  rescue:
-    # Distro repos are turned off in default template
-    # If a new package from fedora/updates is required, this will fix it
-    - dnf:
-        name: "{{ item }}"
-        state: latest
-        enablerepo: fedora,updates
-      with_items:
-        - freeipa-*
-        - python*-ipatests
+  dnf:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+      - freeipa-*
+      - python*-ipatests
 
 - name: create directory to save installed packages logs
   file:


### PR DESCRIPTION
New templates have the required repositories configured properly and
this fallback is no longer needed.

Signed-off-by: Tomas Krizek <tkrizek@redhat.com>

---

**WARNING: Do not merge until https://github.com/freeipa/freeipa-pr-ci/pull/138 is merged and all templates have been updated with properly configured repos!**