### PR TITLE
prci.service: auto-restart service on failure

### DIFF
--- a/ansible/roles/runner/files/prci.service
+++ b/ansible/roles/runner/files/prci.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=FreeIPA PR CI
 After=syslog.target network-online.target libvirtd.service
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
@@ -10,6 +11,8 @@ WorkingDirectory=/root/freeipa-pr-ci
 ExecStart=/bin/bash -c '/root/freeipa-pr-ci/github/prci.py "$(hostname -s)" --config /root/.config/freeipa-pr-ci/config.yml'
 StandardOutput=syslog
 StandardError=syslog
+Restart=on-failure
+RestartSec=10m
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Configure prci.service to be restarted after 10 minutes if it fails.
Rate-limiting of startup is disabled, so systemd will attempt to restart
the service indefinitely as long as it fails.

Fixes: #141
Signed-off-by: Tomas Krizek <tkrizek@redhat.com>