### PR TITLE
Removing use of custom COPR repo

### DIFF
--- a/ansible/roles/runner/tasks/deploy_pr_ci.yml
+++ b/ansible/roles/runner/tasks/deploy_pr_ci.yml
@@ -10,7 +10,10 @@
   pip:
     executable: pip3
     state: present
-    name: github3.py>=1.0.0a4
+    name: "{{ item.name }}"
+  with_items:
+    - name: "github3.py>=1.0.0a4"
+    - name: "CacheControl>=0.12.3"
 
 - name: create config directory if it dosn't exist
   file:

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -10,9 +10,6 @@
     name: dnf-makecache.service
     state: stopped
 
-- name: "enable tkrizek/freeipa-pr-ci COPR"
-  shell: dnf copr enable -y tkrizek/freeipa-pr-ci
-
 - name: install runner dependencies
   dnf:
     name: "{{ item }}"
@@ -33,7 +30,6 @@
     - python3-pip
     - redhat-rpm-config
     - redis
-    - python3-CacheControl
     - python3-redis
     - python3-parse
     - python3-dateutil


### PR DESCRIPTION
Instead of using custom COPR repos, get the packages from pip, since we have the required version there.