### PR TITLE
Changing to install a newer Vagrant version

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -37,3 +37,5 @@ Vagrant.configure(2) do |config|
     end
 
 end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -44,3 +44,5 @@ Vagrant.configure(2) do |config|
         end
     end
 end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -60,3 +60,5 @@ Vagrant.configure(2) do |config|
     end
 
 end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -58,3 +58,5 @@ Vagrant.configure(2) do |config|
     end
 
 end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -61,3 +61,5 @@ Vagrant.configure(2) do |config|
     end
 
 end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -64,3 +64,5 @@ Vagrant.configure(2) do |config|
     end
 
 end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')


### PR DESCRIPTION
As said here [1], a newer version of Vagrant is needed. Otherwise, the process to add a box will fail with a 404, because the "server/repo URL" has been moved.

* Installing new Vagrant version
Instead of relying on fedora packages, this changes the code to get the rpm directly from vagrantcloud source. I prefer to maintain a simple URL that can be easily changed when it's needed.

* Adding the necessary packages to the new version
As can be checked here: https://github.com/vagrant-libvirt/vagrant-libvirt

* This commit also specify the provider (libvirt in our case) to use in
vagrant up, as it's needed by the new vagrant version.

[1] https://groups.google.com/forum/#!msg/vagrant-up/H8C68UTkosU/qz4YUmAgBAAJ