### PR TITLE
Increase the time between requests

### DIFF
--- a/github/prci_github/adapter.py
+++ b/github/prci_github/adapter.py
@@ -36,7 +36,7 @@ class GitHubAdapter(CacheControlAdapter):
             logger.debug('%s: try %d', self.__class__.__name__, try_counter)
 
             # Rate-limit requests to avoid hitting GitHub API abuse limit
-            time.sleep(0.5)
+            time.sleep(1.5)
 
             try:
                 response = super(GitHubAdapter, self).send(


### PR DESCRIPTION
As commit a811f1cc explains, we need to slow down the API calls to avoid
hitting the limit of requests per minute. To have more than ~20 runners, it's necessary to increase this time. Increasing it to 1.5s would allow us to have around 40 runners.

Important to say that the limit is hit even when runners are using the cached requests, as it's well explained in [1].

[1] https://github.com/freeipa/freeipa-pr-ci/tree/master/doc#abuse-limit