### PR TITLE
Updating setuptools to fix problem when installing cachecontrol

### DIFF
--- a/ansible/roles/runner/tasks/deploy_pr_ci.yml
+++ b/ansible/roles/runner/tasks/deploy_pr_ci.yml
@@ -9,9 +9,10 @@
 - name: install python dependencies with pip
   pip:
     executable: pip3
-    state: present
+    state: latest
     name: "{{ item.name }}"
   with_items:
+    - name: "setuptools"
     - name: "github3.py>=1.0.0a4"
     - name: "CacheControl>=0.12.3"
 


### PR DESCRIPTION
When trying to install CacheControl with pip 9.0.1 and setuptools
python3-setuptools-36.0.1-1, it fails with message:
AttributeError: 'NoneType' object has no attribute 'ensure_finalized'

Updating setuptools to latest version (setuptools-38.5.1)
fixes the problem.