### PR TITLE
Adding freeipa-pr-ci user to whitelist

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -10,6 +10,7 @@
 - felipevolpone
 - flo-renaud
 - frasertweedale
+- freeipa-pr-ci
 - frozencemetery
 - germanparente
 - gkaihorodova


### PR DESCRIPTION
We need this to have nightly PRs in freeipa repo