### PR TITLE
Do not use API call for downloading tasks file

### DIFF
--- a/github/prci_github/internals.py
+++ b/github/prci_github/internals.py
@@ -253,68 +253,37 @@ class Tasks(collections.Set, collections.Mapping):
         self.job_cls = job_cls
         self.tasks_conf = {}
 
-        for changed_file in pull.pull.files():
-            if changed_file.filename == tasks_config_path:
-                logger.debug('Tasks file was modified in PR %d. Using tasks '
-                             'file from PR.', pull.pull.number)
-                ref = pull.pull.head.sha
-                tasks_from_pr = True
-                break
-        else:
-            logger.debug('Task file was not modified in PR %d. Using tasks '
-                         'file from target branch', pull.pull.number)
-            ref = pull.pull.base.ref
-            tasks_from_pr = False
+        def log_retrieve(url):
+            logger.debug("Retrieving tasks file: %s", url)
 
-        # TODO: Use API once most of the PRs have tasks file
-        # tasks_file = repo.file_contents(tasks_config_path, ref)
-        # if not tasks_file:
-        #     if tasks_from_pr:
-        #         logger.warning('Tasks file was removed in PR %d',
-        #                        pull.pull.number)
-        #     else:
-        #         logger.warning('Tasks file not present in target branch %s',
-        #                        pull.pull.base.ref)
-        # else:
-        #     try:
-        #         self.tasks_conf = yaml.load(
-        #                             base64.b64decode(tasks_file.content)
-        #                           )['jobs']
-        #     except (yaml.error.YAMLError, TypeError, KeyError) as err:
-        #         if tasks_from_pr:
-        #             logger.warning('Failed to decode tasks file from PR %d: '
-        #                            '%s', pull.pull.number, err)
-        #         else:
-        #             logger.warning('Failed to decode tasks file from branch '
-        #                            '%s: %s', pull.pull.base.ref, err)
         tasks_file_url = (
             "https://raw.githubusercontent.com/{repo.owner.login}/{repo.name}/"
-            "{ref}/{tasks_path}".format(repo=repo, ref=ref,
-                                        tasks_path=tasks_config_path)
+            "{ref}/{tasks_path}"
         )
 
-        logger.debug("Retrieving tasks file %s", tasks_file_url)
-
-        session = cachecontrol.CacheControl(requests.session(),
-                                            cache=redis.Redis())
-        response = session.get(tasks_file_url)
-        if response.status_code == 200:
-            try:
-                self.tasks_conf = yaml.load(response.content)['jobs']
-            except (yaml.error.YAMLError, TypeError, KeyError) as err:
-                if tasks_from_pr:
-                    logger.warning('Failed to decode tasks file from PR %d: '
-                                   '%s', pull.pull.number, err)
-                else:
-                    logger.warning('Failed to decode tasks file from branch '
-                                   '%s: %s', pull.pull.base.ref, err)
-        else:
-            if tasks_from_pr:
-                logger.warning('Tasks file was removed in PR %d',
-                               pull.pull.number)
-            else:
-                logger.warning('Tasks file not present in target branch %s',
-                               pull.pull.base.ref)
+        session = cachecontrol.CacheControl(
+            requests.session(), cache=redis.Redis()
+        )
+        url = tasks_file_url.format(
+            repo=repo, ref=pull.pull.head.sha, tasks_path=tasks_config_path
+        )
+        log_retrieve(url)
+        response = session.get(url)
+        if response.status_code != 200:
+            url = tasks_file_url.format(
+                repo=repo, ref=pull.pull.base.ref, tasks_path=tasks_config_path
+            )
+            log_retrieve(url)
+            response = session.get(
+                tasks_file_url.format(url)
+            )
+        try:
+            self.tasks_conf = yaml.load(response.content)['jobs']
+        except (yaml.error.YAMLError, TypeError, KeyError) as err:
+            logger.warning(
+                'Failed to decode tasks file from branch %s: %s',
+                pull.pull.base.ref, err
+            )
 
     def __len__(self):
         return len(Statuses(self.repo, self.pull, self.tasks_conf.keys()))


### PR DESCRIPTION
Now downloading tasks file is using an GitHub API call
(GET /repos/:owner/:repo/pulls/:number/files). It can be useful
in some cases but not in ours. In our case the `.freeipa-pr-ci.yaml`
file exists either in the head or base branches. So we can retrieve
it just by constructing the URL. So then if the tasks file doesn't
exist in the head, we will just download it from the base.