### PR TITLE
Fix keyerror when trying to get tasks file

### DIFF
--- a/github/prci_github/internals.py
+++ b/github/prci_github/internals.py
@@ -274,9 +274,7 @@ class Tasks(collections.Set, collections.Mapping):
                 repo=repo, ref=pull.pull.base.ref, tasks_path=tasks_config_path
             )
             log_retrieve(url)
-            response = session.get(
-                tasks_file_url.format(url)
-            )
+            response = session.get(url)
         try:
             self.tasks_conf = yaml.load(response.content)['jobs']
         except (yaml.error.YAMLError, TypeError, KeyError) as err:


### PR DESCRIPTION
Previous code was raising `KeyError: 'repo'` on `tasks_file_url.format(url)`. We should only pass url as a parameter to session.get.