### PR TITLE
Screenshots support for Web UI testing

### DIFF
--- a/ansible/roles/machine/provision_ipaserver/templates/ui_test.conf.j2
+++ b/ansible/roles/machine/provision_ipaserver/templates/ui_test.conf.j2
@@ -30,7 +30,8 @@ browser: firefox
 
 # Screenshots
 # ===========
-save_screenshots: False
+save_screenshots: True
+screenshot_dir: /vagrant/
 
 # Geckodriver setup:
 # =================


### PR DESCRIPTION
Changing ui_test.conf to enable screenshot saving and publishing them with
other artifacts.

With this, a screenshot for all failures of Web UI tests will be captured
if test has a @screnshot decorator.

It is also possible to use manual screenshot saving:
    self.take_screenshot("my-screenshot-name")