### PR TITLE
Export junit.xml in pytest to allow automatic processing

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -247,7 +247,8 @@ class RunPytest(JobTask):
                 'IPATEST_YAML_CONFIG=/vagrant/ipa-test-config.yaml '
                 '{run_tests_cmd} {test_suite} '
                 '--verbose --logging-level=debug --logfile-dir=/vagrant/ '
-                '--html=/vagrant/report.html'
+                '--html=/vagrant/report.html '
+                '--junit-xml=/vagrant/junit.xml'
                 ).format(
                     run_tests_cmd=self.run_tests_cmd,
                     test_suite=self.test_suite)],


### PR DESCRIPTION
We can easily produce also junit.xml so that system which can automatically
process it can do it from published artifacs. This might be one of the ways
how to automatically process nightly or other testing results.