### PR TITLE
Ensure firewalld is installed and configured

### DIFF
--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -26,6 +26,7 @@
     - createrepo
     - gzip
     - gcc
+    - firewalld
     - python3-devel
     - python3-pip
     - redhat-rpm-config
@@ -39,8 +40,30 @@
     - python3-tqdm
     - python3-pytz
     - python3-jinja2
+    - python-firewall
+    - python3-firewall
   notify:
     - restart_nfs
+
+- name: enable firewalld
+  service:
+    name: firewalld
+    enabled: true
+    state: started
+
+- name: configure firewalld
+  firewalld:
+    service : "{{ item }}"
+    permanent: true
+    state: enabled
+  with_items:
+    - nfs
+    - ipp
+    - rpc-bind
+    - mountd
+
+- name: reload firewalld
+  shell: firewall-cmd --reload
 
 - name: start&enable nfs
   service:


### PR DESCRIPTION
Now runner preparation does not configure firewalld service and
open ports for NFS related services. As the result Vagrant can't
mount NFS directory so no task will be run.

This patch eliminates this kind of thing.