### PR TITLE
Install Python packages from Fedora repo

### DIFF
--- a/ansible/roles/runner/tasks/deploy_pr_ci.yml
+++ b/ansible/roles/runner/tasks/deploy_pr_ci.yml
@@ -6,16 +6,6 @@
     version: "{{ pr_ci_repo_branch }}"
     force: true
 
-- name: install python dependencies with pip
-  pip:
-    executable: pip3
-    state: latest
-    name: "{{ item.name }}"
-  with_items:
-    - name: "setuptools"
-    - name: "github3.py>=1.0.0a4"
-    - name: "CacheControl>=0.12.3"
-
 - name: create config directory if it dosn't exist
   file:
     path: /root/.config/freeipa-pr-ci

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -39,6 +39,8 @@
     - python3-tqdm
     - python3-pytz
     - python3-jinja2
+    - python3-github3py
+    - python3-CacheControl
   notify:
     - restart_nfs
 


### PR DESCRIPTION
Now almost every Python package that are dependencies for runner's
code getting installed from Fedora repository, except of github3 and
CacheControl.

This patch removes pip usage and makes ansible to install required
packages from the Fedora repo.