### PR TITLE
Upgrade runner's packages during its setup

### DIFF
--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -10,6 +10,11 @@
     name: dnf-makecache.service
     state: stopped
 
+- name: upgrade packages
+  dnf:
+    name: "*"
+    state: latest
+
 - name: install runner dependencies
   dnf:
     name: "{{ item }}"


### PR DESCRIPTION
Now the runner's packages are not getting upgraded and this leads
to many problems, such as security issues or not working executables.

This patch adds dnf upgrade call during runner's setup.