### PR TITLE
Make logger format fancy

### DIFF
--- a/ansible/roles/runner/templates/config.yml
+++ b/ansible/roles/runner/templates/config.yml
@@ -10,7 +10,7 @@ logging:
     version: 1
     formatters:
         basic:
-            format: '%(levelname)s:%(name)s:%(message)s'
+            format: '%(levelname)s: %(name)s: %(message)s'
     handlers:
         console:
             class: logging.StreamHandler


### PR DESCRIPTION
Now logger format doesn't contain spaces after its level name,
module name and the message.

This patch adds spaces so log becomes a little easier to read.