### PR TITLE
Decreasing time between each request

### DIFF
--- a/github/prci_github/adapter.py
+++ b/github/prci_github/adapter.py
@@ -36,7 +36,7 @@ class GitHubAdapter(CacheControlAdapter):
             logger.debug('%s: try %d', self.__class__.__name__, try_counter)
 
             # Rate-limit requests to avoid hitting GitHub API abuse limit
-            time.sleep(1.5)
+            time.sleep(0.5)
 
             try:
                 response = super(GitHubAdapter, self).send(


### PR DESCRIPTION
With 1.5 seconds of delay, the runners could wait more than 1,5 hours to
get a new task (depending on the number of PRs). Switching it back to
0.5 to decrease this time even though this limit the number of maximum
runners.