### PR TITLE
Artifacts: do not compress screenshots (png files)

### DIFF
--- a/tasks/remote_storage.py
+++ b/tasks/remote_storage.py
@@ -17,6 +17,7 @@ class GzipLogFiles(PopenTask):
             '-a ! -path "*/assets/*" '
             '-a ! -path "*/rpms/*" '
             '-a ! -name "*.gz" '
+            '-a ! -name "*.png" '
             '-a ! -name "Vagrantfile" '
             '-a ! -name "ipa-test-config.yaml" '
             '-a ! -name "vars.yml" '


### PR DESCRIPTION
Screenshot is a png - already compressed. GZIP compression doesn't save much
additional space.

Compressing screenshots creates UX issue: Firefox is not able to directly
open png.gz file. So one must download it, uncompress and then open which
takes time.

By not compressing screenshots, one can easily view Web UI test failure
directly from uploaded artifacts.