### PR TITLE
tasks/vagrant.py VagrantCleanup fix

### DIFF
--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -70,14 +70,24 @@ class VagrantCleanup(VagrantTask):
                 PopenTask(['vagrant', 'destroy']))
         except PopenException:
             self.execute_subtask(
-                PopenTask(['pkill', '-9', 'bin/vagrant'],
+                PopenTask(['pkill', '-9', '-f', '".*/bin/vagrant.*"'],
                           raise_on_err=False))
             self.execute_subtask(
-                PopenTask(['systemctl', 'restart', 'libvirt'],
+                PopenTask(['systemctl', 'restart', 'libvirtd'],
                           raise_on_err=False))
             self.execute_subtask(
                 PopenTask(['vagrant', 'destroy'],
                           raise_on_err=False))
+            self.execute_subtask(
+                PopenTask(
+                    [
+                        'pkill', '-9', '-f',
+                        '".*(\/bin\/qemu-system-x86_64).*'
+                        '(master|replica|client|controller)*"'
+                    ],
+                    raise_on_err=False
+                )
+            )
 
 
 class VagrantBoxDownload(VagrantTask):


### PR DESCRIPTION
Now the fallback after Vagrant destroy PopenException is completely
useless as it will not kill Vagrant and will not restart libvirtd
service.

This patch fixes it.

Also added pkill call to make sure there are no lost virtual machines.