### PR TITLE
Use tuned to make optimizations for runners

### DIFF
--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -15,6 +15,7 @@
     name: "{{ item }}"
     state: present
   with_items:
+    - tuned
     - vagrant
     - vagrant-libvirt
     - libguestfs-tools-c  # required for vagrant package command
@@ -47,6 +48,15 @@
     name: nfs
     enabled: true
     state: started
+
+- name: start&enable tuned
+  service:
+    name: tuned
+    enabled: true
+    state: started
+
+- name: select tuned profile
+  shell: tuned-adm profile virtual-host
 
 - name: start&enable libvirt services
   service:


### PR DESCRIPTION
Tuned is a profile-based system tuning tool that uses the udev device
manager to monitor connected devices, and enables both static and
dynamic tuning of system settings.

As the runner is virtual hosts for Vagrant machines it's good to have
it's kernel optimized for such workloads. To achieve this we need to
have tuned service enabled and running. Then, we need to activate a
virtual-host profile so tuned will make necessary changes in sysctl.

>> virtual-host decreases the swappiness of virtual memory and enables
>> more aggressive writeback of dirty pages.