### PR TITLE
Fix poll_status to raise EnvironmentError

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -176,7 +176,7 @@ class World(object):
         statuses = util.get_statuses(commit)
         status = util.get_status(statuses, task_name)
         if not status:
-            raise RuntimeError("Can't parse status data.")
+            raise EnvironmentError("Can't parse status data.")
 
         return Status.from_dict(status)
 


### PR DESCRIPTION
Now poll_status method of a World class throws the RuntimeError
which is not being catched so the whole PR CI instance dies.

This patch fixes it.