### PR TITLE
Task.lock: don't lock already processed task

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -584,7 +584,14 @@ class Task(object):
         """
         status = world.poll_status(self.pr_number, self.name)
 
-        if status is not None and status.pending and status.taken:
+        if status.failed or status.succeeded:
+            raise EnvironmentError(
+                "Task '{}' PR#{} was already processed.".format(
+                    self.name, self.pr_number
+                )
+            )
+
+        if status.pending and status.taken:
             raise EnvironmentError(
                 "Task '{}' PR#{} is already locked.".format(
                     self.name, self.pr_number


### PR DESCRIPTION
Now the already processed (succeeded and failed) task will be
locked if it was gathered and yielded by prci before it was
taken by any runner and changed status from pending.

This patch adds the check for this kind of thing to the lock
method of Task class and fixes the behaviour.