### PR TITLE
Fix tasks creation on GitHub

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -625,14 +625,17 @@ class Task(object):
         """
         try:
             status = world.poll_status(self.pr_number, self.name)
-            if status.processing:
-                raise EnvironmentError(
-                    "Already processing task {} PR#{}".format(
-                        self.name, self.pr_number
-                    )
-                )
-        except RuntimeError:
+        except EnvironmentError:
             world.create_status(self, State.PENDING, "unassigned")
+            return
+
+        if status.processing:
+            raise EnvironmentError(
+                "Already processing task {} PR#{}".format(
+                    self.name, self.pr_number
+                )
+            )
+
 
     def set_rerun(self, world: World) -> None:
         """Creates a commit status on GitHub using REST API


### PR DESCRIPTION
After eddec9de2e0ec814e3bc49c5e2759fbc329e09e6 CI can't create
tasks for new PRs as set_unassigned method stopped to catch the
exception as the type of it was changed.

This patch fixes it.