### PR TITLE
[scalability] Fix set_rerun behaviour

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -643,7 +643,13 @@ class Task(object):
         Sets the status description to RERUN_PENDING value.
         """
         status = world.poll_status(self.pr_number, self.name)
-        if status is not None and status.rerun_pending:
+        if status.succeeded or status.taken:
+            raise EnvironmentError(
+                "Task {} PR#{} is changed".format(
+                    self.name, self.pr_number
+                )
+            )
+        if status.rerun_pending:
             raise EnvironmentError(
                 "Task {} PR#{} is already updated for rerun".format(
                     self.name, self.pr_number


### PR DESCRIPTION
Now we can to observe unexpected set_rerun behaviour that can set
rerun pending description to a commit status. It happens because
of the current information gathering cycle when we're getting all
repository information only once per while loop cycle. As the pull
requests are getting processed and tasks are being executed the
state of GitHub repository will most probably change, but the state
inside the cycle remains static. In this case, if pull request had
the rerun label on the moment of information gathering and the
statuses were in failed state, the system will try to change the
status to rerun pending. Now this action will fail only if the
status is already in rerun state.

This patch adds a check if the status is already in a success state
or taken and if so it will be skipped and task will not be created
over and over again and waste our resources and neurons.