### PR TITLE
Deployment: restart the runners after deploy

### DIFF
--- a/ansible/prepare_test_runners.yml
+++ b/ansible/prepare_test_runners.yml
@@ -17,3 +17,17 @@
       deploy_ssh_key: true
       enable_nested_virt: true
       create_systemd_unit: true
+  post_tasks:
+    - name: reboot host
+      shell: sleep 2 && /sbin/shutdown -r now "Packages upgrade"
+      async: 1
+      poll: 0
+      ignore_errors: true
+    - name: wait for server to come back
+      local_action: wait_for
+      args:
+        host: "{{ inventory_hostname }}"
+        port: 22
+        state: started
+        delay: 30
+        timeout: 300


### PR DESCRIPTION
As we now have the packages upgrade process running during deployment,
and auto update is eliminated, we need to reboot the runner after
deployment complete to pick up new kernel, libraries, prci code changes.

This patch adds reboot to the post tasks of deployment.