### PR TITLE
[scalability] Fix behaviour to update stalled task

### DIFF
--- a/github/prci.py
+++ b/github/prci.py
@@ -171,11 +171,11 @@ def process_status(
 
     if status.stalled(task):
         logger.info(
-            "Task %s on PR #%s is stale. Updating for rerun.",
+            "Task %s on PR #%s is stale. Setting unassigned.",
             task.name, task.pr_number
         )
         try:
-            task.set_rerun(world)
+            task.set_unassigned(world)
         except EnvironmentError as e:
             logger.warning(e)
 


### PR DESCRIPTION
Now prci will try to set rerun pending for stalled task and this
update will fail as set_rerun has check if task is taken. In this
case the update of a stalled task will be performed over and over
again that will lead to triggering of abuse limit of GitHub API.

This patch makes the prci to set stalled task status to unassigned
and fixes this problem.