### PR TITLE
Fix set_rerun to allow updating stalled task

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -643,7 +643,7 @@ class Task(object):
         Sets the status description to RERUN_PENDING value.
         """
         status = world.poll_status(self.pr_number, self.name)
-        if status.succeeded or status.taken:
+        if status.succeeded or (status.taken and not status.stalled):
             raise EnvironmentError(
                 "Task {} PR#{} is changed".format(
                     self.name, self.pr_number


### PR DESCRIPTION
Fixes the nasty stupid bug which was introduced in
462607821a914413a12c2c86af21fb2f0fa8d0c2 and leads to not updating
the status to rerun pending when task is stuck.

This patch fixes it by adding a check for a stalled status inside
Task.set_rerun.