### PR TITLE
Cleanup after reprovision of VM fails

### DIFF
--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -9,7 +9,7 @@ def with_vagrant(func):
     def wrapper(self, *args, **kwargs):
         try:
             __setup_provision(self)
-        except TaskException as exc:
+        except (PopenException, TaskException) as exc:
             logging.critical('vagrant or provisioning failed')
             raise exc
         else:


### PR DESCRIPTION
Now __setup_provision procedure reprovisions a box another time
after the first try failed. If provision will fail again it would
leave machines up and running, which will lead to many nasty things.
This happens because PopenException is not being catched in
with_vagrant wrapper.

This patch makes wrapper to catch PopenException to eliminate this
behaviour.