### PR TITLE
Fix failure after PR is forced pushed

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -677,7 +677,15 @@ class Task(object):
 
         result = self.job(dependencies_results)
 
-        status = world.poll_status(self.pr_number, self.name)
+        try:
+            status = world.poll_status(self.pr_number, self.name)
+        except EnvironmentError:
+            raise ReferenceError(
+                "Task {} PR#{} was updated".format(
+                    self.name, self.pr_number
+                )
+            )
+
         if status.description != self.description:
             raise EnvironmentError(
                 "Task {} PR#{} was processed by multiple runners".format(

--- a/github/prci.py
+++ b/github/prci.py
@@ -287,6 +287,8 @@ def main():
                 )
                 try:
                     task.execute(world, pull_request.commit.statuses)
+                except ReferenceError as e:
+                    logger.warning(e)
                 except (EnvironmentError, RuntimeError) as e:
                     logger.error(e)
                     sentry_report_exception({"module": "github"})


### PR DESCRIPTION
When PR is forced pushed when test is running. The test will be
finished and then PR-CI will error out on status update step with

ERROR: __main__: Can't parse status data.

It is expected as the force push removed the status. But it
causes upload of data to sentry.io.

This patch adds EnvironmentError exception catching into execute
method of a Task class and raises ReferenceError when commit status
is not found. The error logs at a warning level, then runner's
execution proceeds.

Fixes https://github.com/freeipa/freeipa-pr-ci/issues/194