### PR TITLE
WIP: ipa-run-webui-tests: changes to accept regexes in test definition

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -319,10 +319,11 @@ class RunWebuiTests(RunPytest):
     def execute_tests(self):
         self.execute_subtask(
             PopenTask(['vagrant', 'ssh', '-c', (
-                'ipa-run-webui-tests {test_suite} '
+                'ipa-run-webui-tests '
                 '--verbose --logging-level=debug --logfile-dir=/vagrant/ '
                 '--html=/vagrant/report.html '
-                '--junit-xml=/vagrant/junit.xml'
+                '--junit-xml=/vagrant/junit.xml '
+                '{test_suite}'
                 ).format(test_suite=self.test_suite)],
                 timeout=None))
 


### PR DESCRIPTION
Currently when setting regexes in test definition in prci yaml
those are not properly expanded after coming from vagrant ssh
command and through ipa-run-webui-tests wrapper. Thus we are
taking different approach and getting them from tests directory
rather then passing it directly to pytest.