### PR TITLE
Making PR CI nightly tests definition editable by FreeIPA contributors

### DIFF
--- a/ansible/prepare_openclose_pr_tool.yml
+++ b/ansible/prepare_openclose_pr_tool.yml
@@ -18,6 +18,7 @@
     - name: repo_owner
       prompt: "Repo owner to create branches"
       private: false
+      default: "freeipa-pr-ci"
 
     - name: github_token
       prompt: "GitHub token"

--- a/ansible/prepare_openclose_pr_tool.yml
+++ b/ansible/prepare_openclose_pr_tool.yml
@@ -24,7 +24,8 @@
       private: false
 
     - name: prci_config
-      prompt: "Provide a path to a .freeipa-pr-ci.yaml file to use it to open new PRs"
+      prompt: "Provide the path to a test definition file to use it to open new
+               PRs. For example: ipatests/prci_definition/gating"
       private: false
     
     - name: git_sshkey

--- a/ansible/roles/automation/openclose_pr/tasks/main.yml
+++ b/ansible/roles/automation/openclose_pr/tasks/main.yml
@@ -34,11 +34,6 @@
     src: "{{ playbook_dir }}/../github/open_close_pr.py"
     dest: "{{ basedir }}"
 
-- name: copy custom freeipa-pr-ci.yaml file
-  copy:
-    src: "{{ prci_config }}"
-    dest: "{{ basedir }}/{{ identifier }}.yaml"
-
 - name: copy git ssh key
   copy:
     src: "{{ git_sshkey }}"
@@ -80,7 +75,7 @@
            --id {{ identifier }}
            --repo_path {{ basedir }}/freeipa
            --branch {{ branch }}
-           --prci_config {{  basedir }}/{{ identifier }}.yaml
+           --prci_config {{ prci_config }}
            --pr_against_upstream {{ pr_against_upstream | bool }}
            open_pr
     user: root

--- a/doc/README.md
+++ b/doc/README.md
@@ -429,14 +429,20 @@ refreshed.
 
 ### PR Scheduler
 With the need of scheduling nightly PRs, a tool was design to do that. It's a
-python script which creates a PR in a GH repo, committing a change in the
-`.freeipa-pr-ci.yaml` file.
+python script which creates a PR in a GH repo, changing in the 
+`.freeipa-pr-ci.yaml` to point to a different test definition file.
 
 The script needs a freeipa fork to work, because it will use this fork to create
 branches and open PRs. You can run the ansible playbook multiple times to
-schedule multiple PRs, but to each PR you want to create you need to provide a
-different identifier (ID). This ID is used to create the branch and to name the
-PR.
+schedule multiple PRs, but to each kind of PR you want to create you need to
+provide a different identifier (ID). This ID is used to create the branch and to
+name the PR.
+
+The playbook will ask for a repo owner, by default `freeipa-pr-ci` should be
+used. This user has a freeipa fork and we use it to open PRs against
+freeipa/freeipa repo. The playbook will also ask for a token, the token is how
+we authenticate the user against GH API. The token from `freeipa-pr-ci` user
+should be used.
 
 To deploy it in some VM, you can use the `prepare_openclose_pr_tool.yml` ansible
 playbook.
@@ -450,6 +456,7 @@ Then run:
 ```
 ansible-playbook -i ansible/hosts/runners ansible/prepare_openclose_pr_tool.yml
 ```
+
 
 ## How to run available unit tests
 Make a venv and then in a project root run

--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -465,6 +465,10 @@ class PullRequest(object):
         Returns:
             dict: Dictionary of a tasks defined in the tasks file.
         """
+        # the .freeipa-pr-ci is a link to a file, first we need to get it
+        # and then get the file it points
+        task_link = self.__get_tasks_file_content(world)
+        world.tasks_path = task_link.decode()
         tasks_file_content = self.__get_tasks_file_content(world)
         return yaml.load(tasks_file_content)["jobs"]
 

--- a/github/open_close_pr.py
+++ b/github/open_close_pr.py
@@ -4,7 +4,6 @@ import os
 import github3
 import argparse
 import logging
-import shutil
 import yaml
 from cachecontrol.adapter import CacheControlAdapter
 import git
@@ -57,10 +56,12 @@ class AutomatedPR(object):
         # creates new branch using the identifier as the name
         repo.git.checkout('-b', args.id)
 
-        prci_config_file = os.path.join(args.repo_path,
+        current_prci_test_config = os.path.join(args.repo_path,
                                         FREEIPA_PRCI_CONFIG_FILE)
 
-        shutil.copy(new_prci_config, prci_config_file)
+        # changing the file that FREEIPA_PRCI_CONFIG_FILE points to
+        os.unlink(current_prci_test_config)
+        os.symlink(new_prci_config, current_prci_test_config)
 
         repo.git.add(FREEIPA_PRCI_CONFIG_FILE)
         repo.git.commit('-m', DEFAULT_COMMIT_MSG)
@@ -148,7 +149,8 @@ def create_parser():
 
     parser.add_argument(
         '--prci_config', type=str, required=True,
-        help='Path to a new .freeipa-pr-ci.yml file'
+        help="Relative path to PR CI test definition (yaml) file in "
+             "FreeIPA repo. E.g: ipatests/prci_definitions/gating"
     )
 
     parser.add_argument(


### PR DESCRIPTION
Now the .freeipa-pr-ci.yaml it's just a symlink to a file that actually has the definition of the tests. This commit changes the tool that schedules the nightly tests.

The major change is that the "--prci_config" parameter now receives a relative path that will change to where the .freeipa-pr-ci.yaml link points