### PR TITLE
Define `with_python2 1` for rpm building

### DIFF
--- a/ansible/roles/builder/build/tasks/create_rpms.yml
+++ b/ansible/roles/builder/build/tasks/create_rpms.yml
@@ -9,6 +9,7 @@
 - name: create rpms
   shell: |
     mock --rebuild /root/rpmbuild/SRPMS/*.src.rpm \
+      --define 'with_python2 1' \
       --result /root/rpmbuild/RPMS/
 
 - name: remove srpm artifact from RPMS dir


### PR DESCRIPTION
FreeIPA will not build python2-* rpms by default soon but we
still may want to test those that are left.

-----------

This should hopefully allow for https://github.com/freeipa/freeipa/pull/1563 to proceed and should not affect any other builds.