### PR TITLE
Reverting firewalld configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ from the up-to-date code should fix such issues.
 
 ### Side notes about deployment
 
+#### Firewall configuration
+If it happened you use firewalld on your machine you wish to install runner
+on you should open ports for nfs, ipp, rpc-bind and mountd. Otherwise Vagrant
+will not mount the shared volume.
+
+If you're deploying freeipa-pr-ci on the FreeIPA infrastructure you don't
+need to care about firewalld as all of the security rules are managed by
+external firewall.
+
 #### Runner deployment automation
 
 By default, ansible will prompt for API token and other variables. To fully

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -24,7 +24,7 @@
     - vagrant
     - vagrant-libvirt
     - libguestfs-tools-c  # required for vagrant package command
-    - ansible  # TODO requires >= 2.3 
+    - ansible  # TODO requires >= 2.3
     - nfs-utils
     - git
     - libvirt
@@ -32,12 +32,9 @@
     - createrepo
     - gzip
     - gcc
-    - firewalld
     - python3-devel
     - python3-pip
     - redhat-rpm-config
-    - python-firewall
-    - python3-firewall
   notify:
     - restart_nfs
 
@@ -47,26 +44,6 @@
     src: mime.types
     dest: /etc/mime.types
     mode: 0644
-
-- name: enable firewalld
-  service:
-    name: firewalld
-    enabled: true
-    state: started
-
-- name: configure firewalld
-  firewalld:
-    service : "{{ item }}"
-    permanent: true
-    state: enabled
-  with_items:
-    - nfs
-    - ipp
-    - rpc-bind
-    - mountd
-
-- name: reload firewalld
-  shell: firewall-cmd --reload
 
 - name: start&enable nfs
   service:


### PR DESCRIPTION
As the Fedora 28 doesn't have Python 2 bindings to firewalld and
ansible needs them by default to manage firewalld I'm removing
the firewalld configuration from the deployment process of the
runner.

Please note that as the part of FreeIPA team you should not worry
about it as our infrastructure has external firewall which manages
security rules.