### PR TITLE
Changing volume caching from 'none' to 'unsafe'

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -21,8 +21,7 @@ Vagrant.configure(2) do |config|
         # Disable graphics
         domain.graphics_type = "none"
 
-        # Recommended for remote NFS storage
-        domain.volume_cache = "none"
+        domain.volume_cache = "unsafe"
     end
 
     config.vm.define "builder"  do |builder|

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -27,8 +27,7 @@ Vagrant.configure(2) do |config|
         # Disable graphics
         domain.graphics_type = "none"
 
-        # Recommended for remote NFS storage
-        domain.volume_cache = "none"
+        domain.volume_cache = "unsafe"
     end
 
     config.vm.define "master"  do |master|

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -27,8 +27,7 @@ Vagrant.configure(2) do |config|
         # Disable graphics
         domain.graphics_type = "none"
 
-        # Recommended for remote NFS storage
-        domain.volume_cache = "none"
+        domain.volume_cache = "unsafe"
     end
 
     config.vm.define "controller" , primary: true do |controller|

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -27,8 +27,7 @@ Vagrant.configure(2) do |config|
         # Disable graphics
         domain.graphics_type = "none"
 
-        # Recommended for remote NFS storage
-        domain.volume_cache = "none"
+        domain.volume_cache = "unsafe"
     end
 
     config.vm.define "controller" , primary: true do |controller|

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -27,8 +27,7 @@ Vagrant.configure(2) do |config|
         # Disable graphics
         domain.graphics_type = "none"
 
-        # Recommended for remote NFS storage
-        domain.volume_cache = "none"
+        domain.volume_cache = "unsafe"
     end
 
     config.vm.define "controller" , primary: true do |controller|

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -27,8 +27,7 @@ Vagrant.configure(2) do |config|
         # Disable graphics
         domain.graphics_type = "none"
 
-        # Recommended for remote NFS storage
-        domain.volume_cache = "none"
+        domain.volume_cache = "unsafe"
     end
 
     config.vm.define "controller" , primary: true do |controller|


### PR DESCRIPTION
Qcow2 file backend can be significantly slow with cache mode 'none'
setting. This happens because the actual file data is fragmented. In
other words, the qcow2 file remain a sparse one with only short stroke
of allocation (for metadata).

So it's better to have an aggressive VFS RAM caching to have a better
random access speed.

The key aspect of this unsafe mode, is that all flush commands from the
guests are ignored. Using this mode implies that the user has accepted
the trade-off of performance over risk of data loss in the event of a
host failure. As we are using virtual machines only for a short period
of time it's safe to use it.