### PR TITLE
remote_storage: switch from Fedora infra to AWS S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ handled by our tooling.
 - GitHub token with *Full control of private repositories* (Settings ->
   Personal access tokens)
 - `freeipa_pr_ci` private key placed in `keys/`
+- Cloud `config` and `credentials` files in `keys/`
 - private keys in `keys/` have permissions set to 0600
 
 ### Development runner deployment

--- a/ansible/roles/runner/defaults/main.yml
+++ b/ansible/roles/runner/defaults/main.yml
@@ -2,6 +2,7 @@
 deploy_ssh_key: false
 enable_nested_virt: false
 create_systemd_unit: false
+cloud_conf_dir: /root/.aws
 ssh_key_dir: /root/.ssh
 monitored_repo_owner: freeipa
 monitored_repo_name: freeipa

--- a/ansible/roles/runner/files/mime.types
+++ b/ansible/roles/runner/files/mime.types
@@ -1,0 +1,5 @@
+text/plain                                      log
+text/plain                                      cfg
+text/plain                                      yml yaml
+text/css                                        css
+text/html                                       html

--- a/ansible/roles/runner/tasks/add_cloud_conf_files.yml
+++ b/ansible/roles/runner/tasks/add_cloud_conf_files.yml
@@ -1,0 +1,18 @@
+---
+- name: "make sure {{ cloud_conf_dir }} exists"
+  file:
+    path: "{{ cloud_conf_dir }}"
+    state: directory
+    mode: 0700
+
+- name: add cloud config file
+  copy:
+    src: ../keys/config
+    dest: "{{ cloud_conf_dir }}/config"
+    mode: 0600
+
+- name: add cloud credentials file
+  copy:
+    src: ../keys/credentials
+    dest: "{{ cloud_conf_dir }}/credentials"
+    mode: 0600

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 - include: manage_ssh_keys.yml
   when: deploy_ssh_key
-  tags: fedorapeople
+  tags: deployment
+- include: add_cloud_conf_files.yml
+  tags: cloud_upload
 - include: enable_nested_virt.yml
   when: enable_nested_virt
   tags: nested_virt

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -41,6 +41,13 @@
   notify:
     - restart_nfs
 
+# adding after packages install as the file can be overwritten by "mailcap"
+- name: add mime.types so awscli can correctly guess content-types
+  copy:
+    src: mime.types
+    dest: /etc/mime.types
+    mode: 0644
+
 - name: enable firewalld
   service:
     name: firewalld

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,9 +17,9 @@ is chosen from a queue that is periodically constructed by polling
 GitHub API for PRs. To execute a job, runners use custom VM templates which are
 downloaded from [VagrantCloud](https://app.vagrantup.com/freeipa). Once a job
 finishes, logs are uploaded to
-[fedorapeople.org](https://fedorapeople.org/groups/freeipa/prci/) where they're
-publicly accessible to the community. Finally, the job result along with the logs'
-URL are reported to GitHub via a
+[Amazon AWS S3 "freeipa-org-pr-ci" bucket](http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/)
+where they're publicly accessible to the community. Finally, the job result along
+with the logs' URL are reported to GitHub via a
 [commit status](https://developer.github.com/v3/repos/statuses/).
 
 ### A. Generating the job queue
@@ -136,7 +136,7 @@ config file to the target branch.
 ![phase-C](images/phase-C.svg)
 
 Once the job is finished (or killed), it will upload the logs to
-fedorapeople.org using rsync and `freeipa_pr_ci` ssh key. These logs are
+Amazon AWS S3 using awscli. These logs are
 publicly accessible and their URL will be generated and reported to the commit
 status of the PR's job. The commit status' *state* will change to one of
 `success`/`failure`/`error`. If any of the individual jobs for the PR are

--- a/doc/images/overview.svg
+++ b/doc/images/overview.svg
@@ -1036,7 +1036,7 @@
          id="tspan4991"
          x="74.26033"
          y="68.722832"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.59908438px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';stroke-width:0.41993132">fedorapeople.org</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.59908438px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';stroke-width:0.41993132">Amazon AWS S3</tspan></text>
     <rect
        ry="0.79228204"
        y="71.431152"

--- a/doc/images/phase-C.svg
+++ b/doc/images/phase-C.svg
@@ -905,7 +905,7 @@
            y="50.241848"
            x="50.911766"
            id="tspan4991"
-           sodipodi:role="line">fedorapeople.org</tspan></text>
+           sodipodi:role="line">Amazon AWS S3</tspan></text>
       <rect
          rx="0.38446796"
          style="opacity:1;fill:#73007e;fill-opacity:0.16579668;stroke:#73007e;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"

--- a/github/prci.py
+++ b/github/prci.py
@@ -119,7 +119,7 @@ def process_pull_request(
     for name, task_data in tasks_data.items():
         task = Task(
             name, pull_request.number, pull_request.commit.sha,
-            repository_url, task_data, JobDispatcher
+            pull_request.author, repository_url, task_data, JobDispatcher
         )
         if task.name not in pull_request.commit.statuses:
             if (

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pytest
 GitPython
 tqdm
 requests
+boto3
+awscli

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -5,10 +5,13 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 TEMPLATES_DIR = os.path.join(BASE_DIR, 'templates')
 JOBS_DIR = os.path.join(BASE_DIR, 'jobs')
 
-FEDORAPEOPLE_KEY_PATH = '/root/.ssh/freeipa_pr_ci'
-FEDORAPEOPLE_DIR = 'ipa-maint@fedorapeople.org:/srv/groups/freeipa/prci/{path}'
-FEDORAPEOPLE_BASE_URL = 'https://fedorapeople.org/groups/freeipa/prci/'
-FEDORAPEOPLE_JOBS_URL = urllib.parse.urljoin(FEDORAPEOPLE_BASE_URL, 'jobs/')
+CLOUD_BUCKET = 'freeipa-org-pr-ci'
+CLOUD_DIR = 's3://freeipa-org-pr-ci/'
+CLOUD_URL = 'http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/'
+CLOUD_JOBS_DIR = 'jobs/'
+CLOUD_JOBS_URL = urllib.parse.urljoin(CLOUD_URL, CLOUD_JOBS_DIR)
+
+TASKS_DIR = os.path.join(BASE_DIR, 'tasks')
 
 BUILD_PASSED_DESCRIPTION = "\(^_^)/"
 BUILD_FAILED_DESCRIPTION = "(✖╭╮✖)"

--- a/tasks/index_template.html
+++ b/tasks/index_template.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <title> FreeIPA PRCI results</title>
+  <link rel="stylesheet" href="//use.fontawesome.com/releases/v5.0.13/css/all.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+</head>
+<body>
+  <a href="{{ cloud_jobs_url }}"><img src="{{ cloud_url }}prci.png"></a>
+  <h4 class="text-center"> {{ obj_data.hostname }} </h4>
+  <h4 class="text-center"> {{ obj_data.uuid }} </h4>
+  <h4 class="text-center"> <a href="https://github.com/freeipa/freeipa/pull/{{ obj_data.pr_number }}"> PR#{{ obj_data.pr_number }} </a> - {{ obj_data.task_name }}
+    {% if obj_data.returncode == '0' %}
+    <i class="fas fa-check" style="color:#28A745"></i> {% else %}
+    <i class="fas fa-times" style="color:#CB2431"></i>
+    {% endif %}</h4>
+  <h4 class="text-center"> Author: <a href="https://github.com/{{ obj_data.pr_author }}/freeipa/"> {{ obj_data.pr_author }} </a></h4>
+  <hr>
+  <div class="container">
+    <table id="results" class="table table-striped">
+      <thead>
+        <tr>
+          <th> Name </th>
+          <th> Date (UTC) </th>
+          <th> Size (B) </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><i class="fas fa-caret-up text-center"><a href="../"> Parent Directory </a></i></td>
+        </tr>
+        {% for item in obj_data.objects %}
+        <tr>
+          {% if item.type == 'dir' %}
+          <td><i class="fas fa-folder"><a href="{{ cloud_jobs_url }}{{obj_data.remote_path }}/{{ item.name }}/"> {{ item.name }} </a></i></td>
+          {% elif item.type == 'file' %}
+          <td><i class="fas fa-file"><a href="{{ cloud_jobs_url }}{{obj_data.remote_path }}/{{ item.name }}"> {{ item.name }} </a></i></td>
+          {% endif %}
+          <td> {{ item.mtime.strftime('%Y-%m-%d %H:%M') }} </td>
+          <td> {{ item.size }} </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</body>

--- a/tasks/remote_storage.py
+++ b/tasks/remote_storage.py
@@ -1,9 +1,220 @@
 import os
 import re
+import concurrent
+import socket
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 
-from .common import PopenTask, TaskException
-from .constants import (FEDORAPEOPLE_KEY_PATH, FEDORAPEOPLE_DIR, UUID_RE,
-                        JOBS_DIR)
+import logging
+import boto3
+from botocore.exceptions import ClientError
+from jinja2 import Template
+
+from .common import PopenTask, TaskException, FallibleTask
+from .constants import (CLOUD_JOBS_DIR, CLOUD_JOBS_URL, CLOUD_URL, CLOUD_DIR,
+                        CLOUD_BUCKET, UUID_RE, JOBS_DIR, TASKS_DIR)
+
+
+"""
+Previously we were updating test results in Fedora infra where the results were
+directly served as part of web server directory listing capabilities. This is
+not case of AWS S3.
+In order to simulate same environment we are generating "index.html" using
+Jinja2 template and putting it into every directory. Then we upload particular
+job directory using awscli (which does parallelism for us) under S3 bucket
+"jobs" prefix (directory). Currently 2 awscli commands are needed in order to
+set correct encoding for gzip files. Content types are set automatically using
+"/etc/mime.types" file.
+At the end we create root jobs index to list all "freeipa" repo PR jobs in the
+bucket.
+"""
+
+
+def get_jobdir_metadata(job_uuid):
+    """
+    Job metadata for root index.
+    """
+    try:
+        client = boto3.client('s3')
+        job = client.head_object(Bucket=CLOUD_BUCKET, Key=job_uuid)
+        name = job_uuid.split(os.sep)[-2]
+        if re.match(UUID_RE, name):
+            mtime = job.get('LastModified')
+            metadata = job.get('Metadata', dict())
+            repo_owner = metadata.get('repo_owner')
+            pr_number = metadata.get('pr_number')
+            pr_author = metadata.get('pr_author')
+            task_name = metadata.get('task_name')
+            returncode = metadata.get('returncode')
+            if repo_owner == 'freeipa':
+                return {'name': name,
+                        'mtime': mtime,
+                        'pr_number': pr_number,
+                        'pr_author': pr_author,
+                        'task_name': task_name,
+                        'returncode': returncode}
+    except ClientError:
+        # lets not fail in case we cannot read metadata of some directory or
+        # there appears a rogue directory without metadata (returns None then)
+        pass
+
+
+def get_jobs():
+    """
+    Get all jobs (directories/objects) from root "jobs" directory. Pagination
+    is needed as S3 client returns only 1000 objects at once.
+    """
+    try:
+        client = boto3.client('s3')
+        paginator = client.get_paginator('list_objects_v2')
+        iterator = paginator.paginate(Bucket=CLOUD_BUCKET,
+                                      Prefix=CLOUD_JOBS_DIR,
+                                      Delimiter='/',
+                                      PaginationConfig={'PageSize': None})
+        for job_uuid in iterator.search('CommonPrefixes'):
+
+            job_dir = job_uuid['Prefix']
+            yield job_dir
+    except ClientError as exc:
+        logging.error('Error while getting job directory list')
+        logging.debug(exc, exc_info=True)
+
+
+def create_jobs_root_index():
+    """
+    Generate root jobs index (only directories) using boto3 client. Threading
+    is needed as polling S3 objects serially is very slow.
+    """
+    try:
+        client = boto3.client('s3')
+        objects = []
+        with ThreadPoolExecutor(max_workers=100) as executor:
+            todo = []
+            for job in get_jobs():
+                future = executor.submit(get_jobdir_metadata, job)
+                todo.append(future)
+            for future in concurrent.futures.as_completed(todo):
+                res = future.result()
+                if res:
+                    objects.append(res)
+
+        objects = sorted(objects, key=lambda k: k['mtime'], reverse=True)
+        obj_data = {'objects': objects}
+
+        client.put_object(Body=generate_index(obj_data, is_root=True),
+                          Bucket=CLOUD_BUCKET, Key=CLOUD_JOBS_DIR+'index.html',
+                          ContentEncoding='utf-8', ContentType='text/html')
+    except ClientError as exc:
+        logging.error('Error while creating root index')
+        logging.debug(exc, exc_info=True)
+
+
+def generate_index(obj_data, is_root=False):
+    """
+    Generate Jinja2 template for index.html with all AWS S3 objects
+    (files and directories).
+    For jobs index we use different template.
+    """
+
+    jinja_ctx = {'obj_data': obj_data, 'cloud_jobs_url': CLOUD_JOBS_URL,
+                 'cloud_url': CLOUD_URL}
+
+    if is_root:
+        template = 'root_index_template.html'
+    else:
+        template = 'index_template.html'
+
+    with open(os.path.join(TASKS_DIR, template), 'r') as file_:
+        template = Template(file_.read())
+    return template.render(jinja_ctx)
+
+
+def write_index(data, path):
+    """
+    Write index.html into every directory (locally).
+    """
+    index_loc = os.path.join(path, 'index.html')
+    with open(index_loc, 'w') as file_:
+        file_.write(generate_index(data))
+
+
+def make_object(root, obj):
+    """
+    Gather particular dir/file data.
+    """
+    fpath = os.path.join(root, obj)
+    fstat = os.stat(fpath)
+    mtime = datetime.fromtimestamp(fstat.st_mtime)
+    size = fstat.st_size
+
+    if os.path.isdir(fpath):
+        o_type = "dir"
+    else:
+        o_type = "file"
+
+    return {
+        "name": obj, "mtime": mtime,
+        "size": size, "type": o_type
+    }
+
+
+def make_objects(root, objects):
+    """
+    Go through subdirs and files in order to gather "object" data.
+    """
+    for f in objects:
+        yield make_object(root, f)
+
+
+def make_aws_data(remote_path, uuid, pr_number, pr_author, task_name,
+                  returncode, hostname, objects):
+    """
+    Create AWS data for Jinja.
+    """
+    return {
+        "remote_path": remote_path, "uuid": uuid, "pr_number": pr_number,
+        "pr_author": pr_author, "task_name": task_name,
+        "returncode": returncode, "hostname": hostname,"objects": objects
+    }
+
+
+def create_local_indeces(uuid, pr_number, pr_author, task_name, returncode,
+                         hostname):
+    """
+    Go through whole job result directory structure and gather all files with
+    metadata for every directory. Note: AWS S3 does not support classic web
+    server browseability capabilities so we do this in order to avoid
+    JavaScript solution on storage side. Also there is no concept of
+    files/directories but rather objects. In this case it is more convenient
+    to do this locally.
+    """
+    job_dir = os.path.join(JOBS_DIR, uuid)
+    job_path_start = job_dir.rfind(os.sep) + 1
+    for root, dirs, files in os.walk(job_dir):
+        remote_path = root[job_path_start:]
+        objects = list(make_objects(root, dirs + files))
+        data = make_aws_data(
+            remote_path, uuid, pr_number, pr_author,
+            task_name, returncode, hostname, objects
+        )
+        write_index(data, root)
+
+
+def assign_jobdir_metadata(uuid, repo_owner, pr_number, pr_author, task_name,
+                           returncode):
+    """
+    Update particular job dir metadata to the object (job uuid directory) for
+    root index listing.
+    """
+    client = boto3.client('s3')
+    job_dir = os.path.join(CLOUD_JOBS_DIR, uuid)
+    metadata = {'repo_owner': repo_owner, 'pr_number': pr_number,
+                'pr_author': pr_author, 'task_name': task_name,
+                'returncode': returncode}
+    client.put_object(Body='',
+                      Bucket=CLOUD_BUCKET,
+                      Key=job_dir+'/',
+                      Metadata=metadata)
 
 
 class GzipLogFiles(PopenTask):
@@ -28,64 +239,60 @@ class GzipLogFiles(PopenTask):
         self.shell = True
 
 
-class RsyncTask(PopenTask):
-    def __init__(self, src, dest, extra_args=None, **kwargs):
-        if extra_args is None:
-            extra_args = []
-
-        cmd = [
-            'rsync',
-            '-r',
-            '--chmod=0755',
-            src,
-            dest
-        ]
-        cmd[2:2] = extra_args  # Extend argument list at index 2
-
-        super(RsyncTask, self).__init__(cmd, **kwargs)
-
-
-class SshRsyncTask(RsyncTask):
-    def __init__(self, src, dest, extra_args=None, ssh_private_key_path=None,
-                 **kwargs):
-        if extra_args is None:
-            extra_args = []
-
-        if ssh_private_key_path is not None:
-            extra_args.extend([
-                '-e',
-                (
-                    'ssh -i {key} '
-                    '-o "StrictHostKeyChecking no" '
-                    '-o "UserKnownHostsFile /dev/null" '
-                    '-o "LogLevel ERROR"'
-                ).format(key=ssh_private_key_path)
-            ])
-
-        super(SshRsyncTask, self).__init__(src, dest, extra_args, **kwargs)
-
-
-class FedoraPeopleUpload(SshRsyncTask):
-    def __init__(self, uuid, **kwargs):
+class CloudUpload(FallibleTask):
+    """
+    Upload PRCI job task artifacts to AWS S3 cloud.
+    """
+    def __init__(self, uuid, repo_owner, pr_number, pr_author, task_name,
+                 returncode, **kwargs):
         if not re.match(UUID_RE, uuid):
             raise TaskException(self, "Invalid job UUID")
+        super(CloudUpload, self).__init__(**kwargs)
+        self.uuid = uuid
+        self.repo_owner = repo_owner
+        self.pr_number = str(pr_number) if not None else ''
+        self.pr_author = pr_author if not None else ''
+        self.task_name = task_name if not None else ''
+        self.returncode = str(returncode) if not None else ''
 
-        super(FedoraPeopleUpload, self).__init__(
-            os.path.join(JOBS_DIR, uuid),
-            FEDORAPEOPLE_DIR.format(path='jobs/'),
-            ssh_private_key_path=FEDORAPEOPLE_KEY_PATH,
-            **kwargs
-        )
+    def _run(self):
+        # make sure we don't leak fqdn
+        self.hostname = socket.gethostname().split('.')[0]
+
+        create_local_indeces(self.uuid, self.pr_number, self.pr_author,
+                             self.task_name, self.returncode, self.hostname)
+
+        src = os.path.join(JOBS_DIR, self.uuid)
+        dest = os.path.join(CLOUD_DIR, CLOUD_JOBS_DIR, self.uuid)
+
+        aws_sync_cmd = ['aws', 's3', 'sync', src, dest]
+        sync_all_except_gz = ['--include=*', '--exclude=*.gz']
+        sync_gz = ['--exclude=*', '--include=*.gz', '--content-encoding=gzip',
+                   '--content-type=text/plain']
+
+        # run 2 awscli commands so we can upload all "gzip" files with
+        # correct encoding.
+        self.execute_subtask(PopenTask(aws_sync_cmd + sync_all_except_gz))
+        self.execute_subtask(PopenTask(aws_sync_cmd + sync_gz))
+
+        try:
+            assign_jobdir_metadata(self.uuid, self.repo_owner, self.pr_number,
+                                   self.pr_author, self.task_name,
+                                   self.returncode)
+        except Exception as exc:
+            raise RuntimeError('Error while assigning metadata:', exc)
 
 
-class FedoraPeopleDownload(SshRsyncTask):
-    def __init__(self, uuid, **kwargs):
-        if not re.match(UUID_RE, uuid):
-            raise TaskException(self, "Invalid job UUID")
+class CreateRootIndex(FallibleTask):
+    """
+    Create jobs root index
+    """
+    def __init__(self, repo_owner, **kwargs):
+        super(CreateRootIndex, self).__init__(**kwargs)
+        self.repo_owner = repo_owner
 
-        super(FedoraPeopleDownload, self).__init__(
-            FEDORAPEOPLE_DIR.format(path='jobs/' + uuid),
-            JOBS_DIR,
-            ssh_private_key_path=FEDORAPEOPLE_KEY_PATH,
-            **kwargs
-        )
+    def _run(self):
+        # list only "freeipa" repo PRs in root index
+        # (Jobs of PRs against forks are not listed)
+        if self.repo_owner == 'freeipa':
+            create_jobs_root_index()

--- a/tasks/root_index_template.html
+++ b/tasks/root_index_template.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <title> FreeIPA PRCI results</title>
+  <link rel="stylesheet" href="//use.fontawesome.com/releases/v5.0.13/css/all.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="//cdn.datatables.net/1.10.18/css/jquery.dataTables.min.css">
+  <script src="//code.jquery.com/jquery-3.3.1.min.js"></script>
+  <script src="//cdn.datatables.net/1.10.18/js/jquery.dataTables.min.js"></script>
+</head>
+<body>
+  <script>
+    $(document).ready(function() {
+        $('#results').DataTable( {
+            "order": [[ 5, "desc" ]],
+            "pageLength": 100,
+            initComplete: function () {
+              this.api().columns().every( function () {
+                  var column = this;
+                  // skip columns for which the search should not be displayed
+                  // 0 = UUID
+                  // 5 = date
+                  var i = column.index();
+                  if (i === 0 || i === 5) return;
+
+                  // cell where to put the select
+                  var th = $(".column-select th")[i];
+                  // clear previous select
+                  $(th).empty();
+
+                  var select = $('<select><option value=""></option></select>')
+                      .prependTo(th)
+                      .on( 'change', function () {
+                          var val = $.fn.dataTable.util.escapeRegex(
+                              $(this).val()
+                          );
+
+                          column
+                              .search( val ? '^'+val+'$' : '', true, false )
+                              .draw();
+                      } );
+
+                  var icon_regex = /(<i[^>]+>[^>^<]*<\/i[^>]*>)/ig
+
+                  column.data().unique().sort().each( function ( d, j ) {
+                      var text = d;
+                      // treat it as HTML
+                      if (text.indexOf('</')> -1) {
+                        // remove icon
+                        text = text.replace(icon_regex, "");
+                      }
+                      if (text.indexOf('<') > -1) {
+                        var el = $(text);
+                        text = el.text();
+                      }
+
+                      select.append($("<option />", { value: text, text: text}))
+                  } );
+              } );
+            }
+            }
+        );
+    } );
+  </script>
+  <a href="{{ cloud_jobs_url }}"><img src="{{ cloud_url }}prci.png"></a>
+  <h4 class="text-center"> List of PRCI "freeipa" PRs job directories </h4>
+  <hr>
+  <div class="container-fluid">
+    <table id="results" class="table table-striped">
+      <thead>
+        <tr class="column-select">
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+        <tr>
+          <th> Name </th>
+          <th> PR # </th>
+          <th> Author </th>
+          <th> Task </th>
+          <th> Status </th>
+          <th> Date (UTC) </th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in obj_data.objects %}
+        <tr>
+          <td><i class="fas fa-folder"><a href="{{ cloud_jobs_url }}{{ item.name }}/"> {{ item.name }} </a></i></td>
+          <td> <a href="https://github.com/freeipa/freeipa/pull/{{ item.pr_number }}"> {{ item.pr_number }} </a></td>
+          {% if item.pr_author == 'freeipa-pr-ci' %}
+            <td> <a href="https://github.com/{{ item.pr_author }}/freeipa/"> nightly </a></td>
+          {% else %}
+            <td> <a href="https://github.com/{{ item.pr_author }}/freeipa/"> {{ item.pr_author }} </a></td>
+          {% endif %}
+          <td> {{ item.task_name }} </td>
+          <td> {% if item.returncode == '0' %}
+            <p class="text-success">PASSED</p> {% else %}
+            <p class="text-danger">FAILED</p> {% endif %} </td>
+          <td> {{ item.mtime.strftime('%Y-%m-%d %H:%M') }} </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <br>
+</body>


### PR DESCRIPTION
Currently we are updating test results in Fedora infra where the results are
    directly served as part of web server directory listing capabilities. This is
    not case of AWS S3.
    In order to simulate same environment we are generating "index.html" using
    Jinja2 template and putting it into every directory. Then we upload particular
    job directory using awscli (which does parallelism for us) under S3 bucket
    "jobs" prefix (directory). Currently 2 awscli commands are needed in order to
    set correct encoding for gzip files. Content types are set automatically using
    "/etc/mime.types" file.
    At the end we create root jobs index to list all jobs in the bucket.
There is also improvement that we can see PR#, author, task name and result together with UUID and filter using datatables.