### PR TITLE
open/close PR tool: install crontabs on the host

### DIFF
--- a/ansible/roles/automation/openclose_pr/tasks/main.yml
+++ b/ansible/roles/automation/openclose_pr/tasks/main.yml
@@ -7,6 +7,7 @@
     - python3-github3py
     - PyYAML
     - git
+    - crontabs
 
 - name: install pip dependencies
   pip:


### PR DESCRIPTION
The Ansible role automation/openclose_pr is used to configure a
machine responsible for creating nightly PRs.
This role configures a cron job launching the script
openclose_pr.py every night at 00:23. The role currently does not
install crontabs package on the machine, which leads to deployment
failure.

This commit modifies the Ansible role so that it also requires
crontabs package installation.