### PR TITLE
machine_template: switch to paramiko system package

### DIFF
--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -3,8 +3,5 @@ selinux_mode: permissive
 copr_repo: "@freeipa/freeipa-master"
 python_packages_to_install:
   - pytest-html
-  - paramiko==2.2.1
-    # It's necessary to use paramiko v2.2.1 due to issues
-    # with gssapi (github.com/paramiko/paramiko/issues/1069)
   - nose
   - selenium

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -38,6 +38,7 @@
     - NetworkManager
     - xorg-x11-server-Xvfb
     - firefox
+    - python3-paramiko
 
 - name: install py3 pip dependencies
   pip:


### PR DESCRIPTION
Due to gssapi issue https://github.com/paramiko/paramiko/issues/1069
in paramiko we were using fixed paramiko==2.2.1 installed by pip. As
the fix for the issue above was backported to Fedora we start using
the recent F28 system package.