### PR TITLE
run "vagrant halt" during template create with privilege escalation

### DIFF
--- a/ansible/roles/box/package/tasks/main.yml
+++ b/ansible/roles/box/package/tasks/main.yml
@@ -10,6 +10,7 @@
 # Turn template VM off and on again. Created vagrant box may not boot if 
 # this step is omitted.
 - name: shutdown template VM
+  become: true
   shell: vagrant halt
   args:
     chdir: "{{ template_box_dir }}"


### PR DESCRIPTION
At the end of creating new vagrant box template script
"create-template-box" fails with permissison denied as we do
not have privileges to halt vagrant machine. Adding "become" also
to "shutdown template VM" task solves the issue.