### PR TITLE
root_index: switch from object metadata to AWS DynamoDB

### DIFF
--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -10,6 +10,8 @@ CLOUD_DIR = 's3://freeipa-org-pr-ci/'
 CLOUD_URL = 'http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/'
 CLOUD_JOBS_DIR = 'jobs/'
 CLOUD_JOBS_URL = urllib.parse.urljoin(CLOUD_URL, CLOUD_JOBS_DIR)
+CLOUD_DB = 'PRCI_JOB_RUN'
+CLOUD_REGION = 'eu-central-1'
 
 TASKS_DIR = os.path.join(BASE_DIR, 'tasks')
 

--- a/tasks/root_index_template.html
+++ b/tasks/root_index_template.html
@@ -99,7 +99,7 @@
           <td> {% if item.returncode == '0' %}
             <p class="text-success">PASSED</p> {% else %}
             <p class="text-danger">FAILED</p> {% endif %} </td>
-          <td> {{ item.mtime.strftime('%Y-%m-%d %H:%M') }} </td>
+          <td> {{ item.mtime }} </td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
We are using jobs root index for a convenience of easily
finding and filtering jobs results, however getting data from
object metadata is very slow and time consuming which can result
in task being timed-out. DynamoDB as part of Amazon AWS stack seems
to be more suitable for this task.

As this functionality is not part of main PRCI job a run should not
fail on this.