### PR TITLE
Add random number generator passthrough

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -17,6 +17,7 @@ Vagrant.configure(2) do |config|
         # Nested virtualization options
         domain.nested = true
         domain.cpu_mode = "host-passthrough"
+        domain.random :model => 'random'
 
         # Disable graphics
         domain.graphics_type = "none"

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
         # Nested virtualization options
         domain.nested = true
         domain.cpu_mode = "host-passthrough"
+        domain.random :model => 'random'
 
         # Disable graphics
         domain.graphics_type = "none"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
         # Nested virtualization options
         domain.nested = true
         domain.cpu_mode = "host-passthrough"
+        domain.random :model => 'random'
 
         # Disable graphics
         domain.graphics_type = "none"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
         # Nested virtualization options
         domain.nested = true
         domain.cpu_mode = "host-passthrough"
+        domain.random :model => 'random'
 
         # Disable graphics
         domain.graphics_type = "none"

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
         # Nested virtualization options
         domain.nested = true
         domain.cpu_mode = "host-passthrough"
+        domain.random :model => 'random'
 
         # Disable graphics
         domain.graphics_type = "none"

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -23,6 +23,7 @@ Vagrant.configure(2) do |config|
         # Nested virtualization options
         domain.nested = true
         domain.cpu_mode = "host-passthrough"
+        domain.random :model => 'random'
 
         # Disable graphics
         domain.graphics_type = "none"


### PR DESCRIPTION
Configure vagrant to use /dev/random passthrough and then configure
haveged on the runners to speed up entropy.