### PR TITLE
prci: do not fail on wrong yaml indentation

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -57,6 +57,10 @@ def sentry_report_exception(context: Dict):
         sentry.context.clear()
 
 
+class JobYAMLError(Exception):
+    pass
+
+
 class CIEnum(Enum):
     """Ordinary enum with a fabric"""
     @classmethod
@@ -552,7 +556,14 @@ class Task(object):
         #           template: *ci-master-f27
         #           timeout: 3600
         #           topology: *master_1repl
-        job_data = task_data["job"]
+
+        if task_data is None:
+            raise JobYAMLError
+        try:
+            job_data = task_data["job"]
+        except (TypeError, KeyError):
+            raise JobYAMLError
+
         job_data["args"]["task_name"] = self.name
         job_data["args"]["pr_number"] = self.pr_number
         job_data["args"]["pr_author"] = self.pr_author


### PR DESCRIPTION
Sometimes there may appear a wrong job definition in prci yaml
which causes the runners to fail.

In the following example we do not have "job" as a value of the task:

~~~
  fedora-28/test_replication_layouts_TestCompleteTopologyWithCAKRA:
  requires: [fedora-28/build]
  priority: 50
  job:
~~~

In case of such mistake we issue a warning and continue to another
task.

The fail is as follows:

~~~
Jul 28 09:40:04 ci-large-12 bash[8083]: Traceback (most recent call last):
Jul 28 09:40:04 ci-large-12 bash[8083]:   File "/root/freeipa-pr-ci/github/prci.py", line 314, in <module>
Jul 28 09:40:04 ci-large-12 bash[8083]:     main()
Jul 28 09:40:04 ci-large-12 bash[8083]:   File "/root/freeipa-pr-ci/github/prci.py", line 287, in main
Jul 28 09:40:04 ci-large-12 bash[8083]:     for task in process_pull_request(world, pull_request, repo_url):
Jul 28 09:40:04 ci-large-12 bash[8083]:   File "/root/freeipa-pr-ci/github/prci.py", line 122, in process_pull_request
Jul 28 09:40:04 ci-large-12 bash[8083]:     pull_request.author, repository_url, task_data, JobDispatcher
Jul 28 09:40:04 ci-large-12 bash[8083]:   File "/root/freeipa-pr-ci/github/internals/entities.py", line 555, in __init__
Jul 28 09:40:04 ci-large-12 bash[8083]:     job_data = task_data["job"]
Jul 28 09:40:04 ci-large-12 bash[8083]: TypeError: 'NoneType' object is not subscriptable
~~~

