### PR TITLE
Scheduler for nightly tests: run on Mon, Wed and Fri

### DIFF
--- a/ansible/roles/automation/openclose_pr/tasks/main.yml
+++ b/ansible/roles/automation/openclose_pr/tasks/main.yml
@@ -70,6 +70,7 @@
     name: "openclose_{{ identifier }}"
     minute: "0"
     hour: "23"
+    weekday: "1,3,5"
     job: >
            python3 {{ basedir }}/open_close_pr.py
            --config {{ basedir }}/config.yml


### PR DESCRIPTION
The current configuration launches the nightly tests everyday. With this
fix, the nightly tests will be run only three times a week, on Monday,
Wednesday and Friday.