### PR TITLE
Remove ipa python2 packages separately

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -19,14 +19,20 @@
     - freeipa-server-common
     - freeipa-server-dns
     - freeipa-server-trust-ad
-    - python2-ipaclient
-    - python2-ipalib
-    - python2-ipaserver
-    - python2-ipatests
     - python3-ipaclient
     - python3-ipalib
     - python3-ipaserver
     - python3-ipatests
+
+# this can be removed when python2 is gone completly
+- name: remove freeipa python2 packages seperately
+  shell: "rpm -e --nodeps '{{ item }}'"
+  with_items:
+    - python2-ipaclient
+    - python2-ipalib
+    - python2-ipaserver
+    - python2-ipatests
+  when: with_python2 is defined and with_python2 == 1
 
 - name: install additional packages
   dnf:

--- a/ansible/vars/ipa_branches/ipa-4-5.yml
+++ b/ansible/vars/ipa_branches/ipa-4-5.yml
@@ -1,2 +1,3 @@
 ---
 freeipa_version: 4-5
+with_python2: 1

--- a/ansible/vars/ipa_branches/ipa-4-6.yml
+++ b/ansible/vars/ipa_branches/ipa-4-6.yml
@@ -1,2 +1,3 @@
 ---
 freeipa_version: 4-6
+with_python2: 1

--- a/ansible/vars/ipa_branches/ipa-4-7.yml
+++ b/ansible/vars/ipa_branches/ipa-4-7.yml
@@ -1,2 +1,3 @@
 ---
 freeipa_version: 4-7
+with_python2: 1


### PR DESCRIPTION
As in the current master we stopped building python2 packages,
any attempt to uninstall them explicitly will fail. In this
case we differentiate uninstallation per branch.