### PR TITLE
Vagrant automation

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.template
+++ b/templates/vagrantfiles/Vagrantfile.template
@@ -1,0 +1,45 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+Vagrant.configure(2) do |config|
+
+    config.ssh.username = "root"
+
+    config.vm.synced_folder "./", "/vagrant",
+        type: "nfs",
+        nfs_udp: false
+
+    config.vm.box = "{{ vagrant_template_name }}"
+    config.vm.box_version = "{{ vagrant_template_version }}"
+
+    config.vm.provider "libvirt" do |domain, override|
+        # Defaults for masters and replica
+        # WARNING: Do not overcommit CPUs, it causes issues during
+        # provisioning, when RPMs are installed
+        domain.cpus = 1
+        domain.memory = 2400
+
+        # Nested virtualization options
+        domain.nested = true
+        domain.cpu_mode = "host-passthrough"
+
+        # Disable graphics
+        domain.graphics_type = "none"
+
+        domain.volume_cache = "unsafe"
+    end
+
+    config.vm.define "controller" , primary: true do |controller|
+        controller.vm.provider "libvirt" do |domain,override|
+            # Less resources needed for controller
+            domain.memory = 950
+        end
+
+        controller.vm.provision :ansible do |ansible|
+            # Disable default limit to connect to all the machines
+            ansible.limit = "all"
+            ansible.playbook = "../../ansible/provision.yml"
+            ansible.extra_vars = "vars.yml"
+        end
+    end

--- a/whitelist.yml
+++ b/whitelist.yml
@@ -46,3 +46,4 @@
 - tomaskrizek
 - tscherf
 - varunmylaraiah
+- dhnunes


### PR DESCRIPTION
Hello People,

This PR implements a simple method that creates the topology definition file in a dynamic way.

To do this, first, we need to implement a new topology definition at trigger file from freeipa:

topologies:
  build: &build
    build:
      cpus: 2
      memory: 6000

  master_1repl_1client: &master_1repl_1client
    master0:
      cpus: 4
      memory: 6700
    replica0:
      cpus: 2
      memory: 3000
    client0:
      cpus: 2
      memory: 1024

With this format and the template implemented on e63aa51, the function will append each machine declared in topology ( master0, replica0, etc ), to Vagrantfile.topology_name, that will be later used to per job execution.