### PR TITLE
Harden PRCI against wrong test definitions

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -251,6 +251,8 @@ class Topology(object):
     @staticmethod
     def from_dict(dict_data: Dict) -> "Topology":
         """Factory for Topology"""
+        if not isinstance(dict_data, dict):
+            raise JobYAMLError
         return Topology(
             name=dict_data.get("name"),
             memory=dict_data.get("memory"),

--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -206,6 +206,22 @@ class World(object):
             target_url, description, task.name
         )
 
+    def create_error_status(
+        self, commit_sha: Text, name: Text, description: Text
+    ) -> None:
+        """Create ERROR commit status on GitHub using REST API
+
+        Raises:
+            github3.exceptions.GitHubError, ValueError
+        """
+        self.check_rest_limit()
+        self.github_api.repository(
+            self.repo_owner, self.repo_name
+        ).create_status(
+            commit_sha, "error",
+            "", description, name
+        )
+
     def __check_limit(self, resource: Text=None) -> None:
         error = None
         for _i in range(API_CHECK_TRIES):

--- a/github/prci.py
+++ b/github/prci.py
@@ -126,6 +126,8 @@ def process_pull_request(
             logger.warning(
                 'Wrong job definition found in PR #%s. Check YAML indentation',
                 pull_request.number)
+            world.create_error_status(pull_request.commit.sha, name,
+                "Test not executed: Wrong job definition")
             continue
         if task.name not in pull_request.commit.statuses:
             if (


### PR DESCRIPTION
Fixes Issue #227 

### Do not crash when test definition is missing a *

The test definition should contain a dict for the topology definition. Usually we are using a repeated node,for instance:
`topology: *master_1repl`
If the test definition is missing the *, then the topology contains a string instead of a dict and PRCI crashes.
The fix properly handles this error.

### Update the test status when the test could not be run

When a test could not be run (wrong YAML content for instance), PRCI simply logs a message in the journal but the dashboard is not updated to reflect the issue.
This commit updates the task status to ERROR and prints "Test not executed: Wrong job definition " so that it does not get unnoticed.

Example:
![update_prci_status](https://user-images.githubusercontent.com/21310191/46276185-99574b00-c55f-11e8-951a-d298cae8ae53.png)
