### PR TITLE
PRCI: when runner fails to publish logs, print hostname

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -110,7 +110,9 @@ class JobTask(FallibleTask):
                             timeout=5*60))
         except Exception as exc:
             logging.debug(exc, exc_info=True)
-            raise TaskException(self, "Failed to publish artifacts")
+            hostname = socket.gethostname().split('.')[0] # don't leak fqdn
+            msg = 'Failed to publish artifacts from {}'.format(hostname)
+            raise TaskException(self, msg)
         else:
             self.remote_url = urllib.parse.urljoin(
                 constants.CLOUD_JOBS_URL, self.uuid)


### PR DESCRIPTION
https://github.com/freeipa/freeipa-pr-ci/issues/230

When a PRCI runner fails to publish the logs, the status on the PR page
simply states: "Failed to publish artifacts", but there is no information
about the machine where the runner failed. This PR adds the hostname, so
that is easy to check the machine and repair the issue.