### PR TITLE
Install, configure and mask firewalld in the machine setup

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -45,6 +45,42 @@
     - xorg-x11-server-Xvfb
     - firefox
     - python3-paramiko
+    - firewalld
+
+# Configure firewalld (make sure that ssh is enabled)
+# This is using the command line tool till python2/3 firewalld import issues
+# are really solved for the ansible firewalld module
+#
+# This can be used later on:
+#   firewalld:
+#     service : "{{ item }}"
+#     permanent: true
+#     state: enabled
+#   with_items:
+#     - ssh
+#
+- name: Configure firewalld
+  command: >
+    firewall-offline-cmd
+    --add-service=ssh
+
+# Mask firewalld - No auto-start and also dbus activation
+# This can be removed when all tests are able to configure firewalld
+#
+# If firwalld will not be masked, please enable the following section as
+# a replacement for masking firewalld:
+#
+# - name: Enable and start firewalld
+#   systemd:
+#     name: firewalld
+#     enabled: yes
+#     state: started
+#
+- name: Mask firewalld
+  systemd:
+    name: firewalld
+    enabled: no
+    masked: yes
 
 - name: install py3 pip dependencies
   pip:


### PR DESCRIPTION
Install firewalld in the machine setup, enable ssh firewall service and
mask firewalld.

For now firewalld gets masked after it has been configured to make sure
that tests that are not able to configure firewalld are still usable.

firewalld is configured using the command line tool. This has been done to
make sure that there is no Python2/3 import issue for the ansible firewalld
module is the firewalld imports are not available for this Python version.
The use of the command line tool has an advantage though: It is only one
call to enable all needed services at once instead of one call per service.

The firewalld service is masked. The mask should to be replaced with a
firewalld reload if all tests are able to configure the firewall.

The reload and also the configuration using the firewalld ansible module
are added to the sections, but commented out.