### PR TITLE
Fedora 29 Base Vagrant Box

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -49,12 +49,12 @@
 - name: install py3 pip dependencies
   pip:
     executable: pip3
-    name: "{{ python_packages_to_install | join(' ') }}"
+    name: "{{ python_packages_to_install }}"
 
 - name: install py2 pip dependencies
   pip:
     executable: pip
-    name: "{{ python_packages_to_install | join(' ') }}"
+    name: "{{ python_packages_to_install }}"
 
 - name: download geckodriver
   shell: |

--- a/ansible/vars/fedora/29.yml
+++ b/ansible/vars/fedora/29.yml
@@ -1,0 +1,9 @@
+---
+fedora_releasever: 29
+base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-29-1.2.x86_64.vagrant-libvirt.box
+
+repo_fedora_enabled: 1
+repo_updates_enabled: 1
+repo_updates_testing_enabled: 0
+repo_freeipa_copr_enabled: 1
+

--- a/ansible/vars/ipa_branches/ipa-4-8.yml
+++ b/ansible/vars/ipa_branches/ipa-4-8.yml
@@ -1,0 +1,3 @@
+---
+freeipa_version: 4-8
+with_python2: 1


### PR DESCRIPTION
Hello,

The intent of this PR is to create the Fedora 29 Vagrant Box used for PR CI to tests, upload it to Vagrant Cloud and add matching files.

1- Vagrant Image is already generated and uploaded to freeipa profile in Vagrant Cloud it can be found here:

https://app.vagrantup.com/freeipa/boxes/ci-master-f29

2 - I've tested this image with a build + simple_replication test, here are the test PR used for this and the results:

https://github.com/dhnunes/freeipa/pull/5
