### PR TITLE
Vagrant: increase memory requirement for master and replicas VMs.

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
         # Defaults for masters and replica
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
-        domain.cpus = 1
+        domain.cpus = 2
         domain.memory = 2400
 
         # Nested virtualization options
@@ -31,10 +31,6 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.define "master"  do |master|
-        master.vm.provider "libvirt" do |domain,override|
-            domain.cpus = 2
-        end
-
         master.vm.provision :ansible do |ansible|
             # Disable default limit to connect to all the machines
             ansible.limit = "all"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
         domain.cpus = 1
-        domain.memory = 2400
+        domain.memory = 2750
 
         # Nested virtualization options
         domain.nested = true
@@ -29,6 +29,7 @@ Vagrant.configure(2) do |config|
 
         domain.volume_cache = "unsafe"
     end
+
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
         domain.cpus = 1
-        domain.memory = 2400
+        domain.memory = 2750
 
         # Nested virtualization options
         domain.nested = true

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
         domain.cpus = 1
-        domain.memory = 2400
+        domain.memory = 2750
 
         # Nested virtualization options
         domain.nested = true

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
         domain.cpus = 1
-        domain.memory = 2400
+        domain.memory = 2750
 
         # Nested virtualization options
         domain.nested = true


### PR DESCRIPTION
Vagrant master and replicas VMs memory consumption is over the limit and eventually causes the PRs to fail with OOM issue. This PR increases the master and replicas memory requirements up to 2750MB.