### PR TITLE
open/close PR tool: fix several bugs

### DIFF
--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -11,12 +11,16 @@
       prompt: "git branch"
       private: false
       default: "master"
+    - name: flow
+      prompt: "template flow"
+      private: false
+      default: "ci"
   vars_files:
     - vars/fedora/{{ fedora_version }}.yml
     - vars/ipa_branches/{{ git_branch }}.yml
   pre_tasks:
     - set_fact:
-        template_box_name: "ci-{{ git_branch }}-f{{ fedora_version }}"
+        template_box_name: "{{ flow  }}-{{ git_branch }}-f{{ fedora_version }}"
   roles:
     - box/prepare
 

--- a/ansible/prepare_openclose_pr_tool.yml
+++ b/ansible/prepare_openclose_pr_tool.yml
@@ -11,11 +11,6 @@
       prompt: "Provide an unique identifier for the PR"
       private: false
 
-    - name: flow
-      prompt: "Flow name to identify the nightly template: ci or pki"
-      private: false
-      default: "ci"
-
     - name: repo_owner
       prompt: "Repo owner to create branches"
       private: false

--- a/ansible/roles/automation/nightly_pr/tasks/main.yml
+++ b/ansible/roles/automation/nightly_pr/tasks/main.yml
@@ -4,7 +4,6 @@
     minute: "{{ item.minute }}"
     hour: "{{ item.hour }}"
     weekday: "{{ item.weekdays }}"
-    flow: "{{ item.flow }}"
     job: >
            python3 {{ basedir }}/open_close_pr.py
            open_nightly_pr
@@ -17,4 +16,4 @@
            --pr_against_upstream {{ pr_against_upstream | bool }}
     user: root
     state: present
-    with_items: "{{ nightly_jobs }}"
+  with_items: "{{ nightly_jobs }}"

--- a/ansible/roles/automation/setup/tasks/setup.yml
+++ b/ansible/roles/automation/setup/tasks/setup.yml
@@ -14,6 +14,7 @@
     - libvirt
     - vagrant-libvirt
     - rsync
+    - libguestfs-tools-c  # required for vagrant package command
 
 - name: install pip dependencies
   pip:
@@ -21,6 +22,7 @@
     executable: pip3
   with_items:
     - CacheControl
+    - requests
     - gitpython
     - ryd
 
@@ -95,3 +97,13 @@
 - name: rename remote origin to mygithub
   shell: "cd {{ basedir }}/freeipa; git remote rename origin mygithub"
   ignore_errors: True
+
+
+- name: start&enable libvirt services
+  service:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+  with_items:
+    - virtlogd
+    - libvirtd

--- a/ansible/roles/automation/template_pr/tasks/main.yml
+++ b/ansible/roles/automation/template_pr/tasks/main.yml
@@ -19,4 +19,4 @@
            --pr_against_upstream {{ pr_against_upstream | bool }}
     user: root
     state: present
-    with_items: "{{  template_jobs }}"
+  with_items: "{{ template_jobs }}"


### PR DESCRIPTION
This commit fixes the following bugs:
- Add missing "flow" variable in create_template_box.yml
- Remove "flow" ansible prompt variable since it is already
  defined for every nightly/template PR definition
- Fix "with_items" indentation bugs
- Add missing ansible "libvirt services restart"
- Add missing "flow" var definition in open_close_pr.py
- Add "--force" on vagrant box remove to avoid prompt confirmation
- Install libguestfs-tools-c for Vagrant packager
- Install "requests" pip requirement
- Fix logger parameters mismatch
- Bump only the corresponding template version