### PR TITLE
Add Active Directory infrastructure support

### DIFF
--- a/ansible/ping.yml
+++ b/ansible/ping.yml
@@ -1,0 +1,16 @@
+---
+- hosts: master:client0
+  roles:
+  - ping
+
+- hosts: ad:ad-child
+  vars:
+  - ansible_connection: winrm
+  - ansible_port: 5986
+  - ansible_user: Administrator
+  - ansible_password: vagrant
+  - ansible_winrm_server_cert_validation: ignore
+  - ansible_winrm_operation_timeout_sec: 60
+  - ansible_winrm_read_timeout_sec: 70
+  roles:
+  - win-ping

--- a/ansible/provision_ad.yml
+++ b/ansible/provision_ad.yml
@@ -1,0 +1,38 @@
+---
+- hosts: ad:ad-child
+  gather_facts: no
+  roles:
+  - win-common
+  vars_files:
+  - variables.yml
+
+- hosts: ad
+  gather_facts: no
+  roles:
+  - win-forest
+  vars_files:
+  - variables.yml
+
+# Continue with AD server after IPA is installed. It seems that the AD server
+# is not ready directly after win_reboot task is finished. This give the server
+# enough time to fully reboot.
+- hosts: ad
+  gather_facts: yes
+  roles:
+  - { role: win-schema, suffix: '{{ ad.suffix }}' }
+  - { role: win-dns, domain: '{{ ad.domain }}', hostname: '{{ ad.hostname }}' }
+  vars_files:
+  - variables.yml
+
+- hosts: ad-child
+  gather_facts: yes
+  roles:
+  - win-domain
+  - { role: win-dns, domain: '{{ ad_child.domain }}', hostname: '{{ ad_child.hostname }}' }
+  vars_files:
+  - variables.yml
+
+- hosts: controller:master:client0
+  gather_facts: yes
+  roles:
+    - machine/provision

--- a/ansible/roles/machine/provision/templates/hosts
+++ b/ansible/roles/machine/provision/templates/hosts
@@ -1,5 +1,7 @@
 127.0.0.1  localhost
 ::1  localhost
 {% for host in groups['all'] %}
-{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['inventory_hostname'] }}.ipa.test
+   {% if 'ansible_default_ipv4' in hostvars[host] %}
+      {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['inventory_hostname'] }}.ipa.test
+   {% endif %}
 {% endfor %}

--- a/ansible/roles/machine/provision/templates/ipa-test-config.yaml
+++ b/ansible/roles/machine/provision/templates/ipa-test-config.yaml
@@ -1,5 +1,5 @@
 ad_admin_name: Administrator
-ad_admin_password: Secret123456
+ad_admin_password: Secret123
 admin_name: admin
 admin_password: Secret.123
 debug: false
@@ -26,6 +26,17 @@ domains:
 {% endfor %}
   name: ipa.test
   type: IPA
+- hosts:
+    - external_hostname: ad.vm
+      ip: 192.168.100.110
+      name: ad.vm
+      role: ad
+    - external_hostname: child.ad.vm
+      ip: 192.168.100.120
+      name: child.ad.vm
+      role: ad_subdomain
+  name: ad.vm
+  type: AD
 nis_domain: ipatest
 ntp_server: 1.pool.ntp.org
 root_ssh_key_filename: /root/.ssh/freeipa_pr_ci_insecure

--- a/ansible/roles/ping/tasks/main.yml
+++ b/ansible/roles/ping/tasks/main.yml
@@ -1,0 +1,2 @@
+- name: Test ansible
+  ping:

--- a/ansible/roles/runner/tasks/deploy_pr_ci.yml
+++ b/ansible/roles/runner/tasks/deploy_pr_ci.yml
@@ -1,6 +1,6 @@
 ---
 - name: clone FreeIPA PR CI repo
-  git: 
+  git:
     dest: /root/freeipa-pr-ci
     repo: "{{ pr_ci_repo }}"
     version: "{{ pr_ci_repo_branch }}"
@@ -33,6 +33,11 @@
 
 - name: systemd daemon reload
   shell: systemctl daemon-reload
+
+# FIXME: something is breaking python3-six installation,
+# so reinstallation is required
+- name: force reinstall python3-six
+  raw: dnf reinstall python3-six -y
 
 - name: enable prci
   service:

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -22,22 +22,46 @@
   with_items:
     - tuned
     - vagrant
+    - vagrant-sshfs
     - vagrant-libvirt
     - libguestfs-tools-c  # required for vagrant package command
     - ansible  # TODO requires >= 2.3
     - nfs-utils
     - git
     - libvirt
+    - libvirt-devel
+    - ruby-devel
     - rsync
     - createrepo
     - gzip
     - gcc
     - python3-devel
     - python3-pip
+    - python3-winrm
+    - python2-winrm
+    - NetworkManager
+    - python-dnf
     - redhat-rpm-config
     - crontabs
   notify:
     - restart_nfs
+
+# as per sssd-suite readme file states, we need vagrant plugins...
+- name: install libvirt plugin for vagrant
+  raw: vagrant plugin install vagrant-libvirt
+  ignore_errors: yes
+
+- name: install vagrant plugin (winrm) for AD tests
+  raw: vagrant plugin install winrm
+  ignore_errors: yes
+
+- name: install vagrant plugins (winrm-fs) for AD tests
+  raw: vagrant plugin install winrm-fs
+  ignore_errors: yes
+
+- name: install vagrant plugins (winrm-elevated) for AD tests
+  raw: vagrant plugin install winrm-elevated
+  ignore_errors: yes
 
 # adding after packages install as the file can be overwritten by "mailcap"
 - name: add mime.types so awscli can correctly guess content-types
@@ -45,6 +69,9 @@
     src: mime.types
     dest: /etc/mime.types
     mode: 0644
+
+- name: force reinstall python3-six
+  raw: dnf reinstall python3-six -y
 
 - name: configure sunrpc to leave kadmin port 749/TCP open
   sysctl:

--- a/ansible/roles/win-common/tasks/main.yml
+++ b/ansible/roles/win-common/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Allow access from our network
+  win_firewall_rule:
+    name: Allow access from our network
+    direction: in
+    action: allow
+    enabled: yes
+    state: present
+
+- name: Install Active Directory Services
+  win_feature:
+    name: '{{ item }}'
+    include_management_tools: yes
+    include_sub_features: yes
+    state: present
+  with_items:
+  - AD-Domain-Services
+  - DNS

--- a/ansible/roles/win-dns/tasks/main.yml
+++ b/ansible/roles/win-dns/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: 'Remove vagrant IP address from DNS'
+  win_shell: |
+    Remove-DnsServerResourceRecord \
+      -ZoneName "{{ item.zone }}"  \
+      -RRType "A"                  \
+      -Name "{{ item.name }}"      \
+      -RecordData "{{ item.ip }}"  \
+      -Force
+  when: inventory_hostname == 'ad'
+  register: dns
+  failed_when: dns.rc != 0 and dns.stderr is not search('ObjectNotFound')
+  changed_when: dns.rc == 0
+  with_items:
+    - { zone: '{{ domain }}', name: '{{ hostname }}', ip: '{{ ansible_ip_addresses[0] }}' }
+    - { zone: '{{ domain }}', name: '{{ domain }}.', ip: '{{ ansible_ip_addresses[0] }}' }

--- a/ansible/roles/win-domain/tasks/main.yml
+++ b/ansible/roles/win-domain/tasks/main.yml
@@ -1,0 +1,26 @@
+- name: 'Create new AD domain {{ ad_child.domain }}'
+  win_shell: |
+    Import-Module ADDSDeployment
+    
+    $user = "Administrator@{{ ad.domain }}"
+    $password = ConvertTo-SecureString -String "vagrant" -AsPlainText -Force
+    $credential = New-Object                                                  \
+      System.Management.Automation.PSCredential($user, $password)
+    
+    Install-ADDSDomain                                                        \
+      -Credential $credential                                                 \
+      -NewDomainName "{{ ad_child.domain|regex_replace('([^.]+).+', '\1') }}" \
+      -ParentDomainName "{{ ad.domain }}"                                     \
+      -NewDomainNetbiosName "{{ ad_child.netbios }}"                          \
+      -Force:$true                                                            \
+      -InstallDns:$true                                                       \
+      -NoRebootOnCompletion:$true                                             \
+      -SafeModeAdministratorPassword                                          \
+        (ConvertTo-SecureString '{{ ad_child.safe_password }}' -AsPlainText -Force)
+  register: installation
+  args:
+    creates: 'C:\Windows\NTDS'
+
+- name: Reboot machine
+  win_reboot:
+  when: installation.changed

--- a/ansible/roles/win-forest/tasks/main.yml
+++ b/ansible/roles/win-forest/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: 'Create new AD forest {{ ad.domain }}'
+  win_shell: |
+    Import-Module ADDSDeployment
+
+    Install-ADDSForest                                                        \
+      -DomainName "{{ ad.domain }}"                                           \
+      -CreateDnsDelegation:$false                                             \
+      -DomainNetbiosName "{{ ad.netbios }}"                                   \
+      -ForestMode "{{ ad.forest_mode }}"                                      \
+      -DomainMode "{{ ad.domain_mode }}"                                      \
+      -Force:$true                                                            \
+      -InstallDns:$true                                                       \
+      -NoRebootOnCompletion:$true                                             \
+      -SafeModeAdministratorPassword                                          \
+        (ConvertTo-SecureString '{{ ad.safe_password }}' -AsPlainText -Force)
+  register: installation
+  args:
+    creates: 'C:\Windows\NTDS'
+
+- name: Reboot machine
+  win_reboot:
+  when: installation.changed

--- a/ansible/roles/win-ping/tasks/main.yml
+++ b/ansible/roles/win-ping/tasks/main.yml
@@ -1,0 +1,2 @@
+- name: Test ansible
+  win_ping:

--- a/ansible/roles/win-schema/files/sudo.schema
+++ b/ansible/roles/win-schema/files/sudo.schema
@@ -1,0 +1,255 @@
+#
+# Active Directory Schema for sudo configuration (sudoers)
+#
+# To extend your Active Directory schema, run one of the following command
+# on your Windows DC (default port - Active Directory):
+# 
+#  ldifde -i -f schema.ActiveDirectory -c "CN=Schema,CN=Configuration,DC=X" #schemaNamingContext
+#
+# or on your Windows DC if using another port (with Active Directory LightWeight Directory Services / ADAM-Active Directory Application Mode)
+# Port 50000 by example (or any other port specified when defining the ADLDS/ADAM instance
+#
+#  ldifde -i -f schema.ActiveDirectory -t 50000 -c "CN=Schema,CN=Configuration,DC=X" #schemaNamingContext
+#
+# or 
+#
+#  ldifde -i -f schema.ActiveDirectory -s server:port -c "CN=Schema,CN=Configuration,DC=X" #schemaNamingContext
+#
+# Can add username domain and password
+#
+# -b username domain password
+#
+# Can create Log file in current or any directory
+#
+# -j .
+#
+
+dn: CN=sudoUser,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoUser
+distinguishedName: CN=sudoUser,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.1
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoUser
+adminDescription: User(s) who may run sudo
+oMSyntax: 22
+searchFlags: 1
+lDAPDisplayName: sudoUser
+name: sudoUser
+schemaIDGUID:: JrGcaKpnoU+0s+HgeFjAbg==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoHost,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoHost
+distinguishedName: CN=sudoHost,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.2
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoHost
+adminDescription: Host(s) who may run sudo
+oMSyntax: 22
+lDAPDisplayName: sudoHost
+name: sudoHost
+schemaIDGUID:: d0TTjg+Y6U28g/Y+ns2k4w==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoCommand,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoCommand
+distinguishedName: CN=sudoCommand,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.3
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoCommand
+adminDescription: Command(s) to be executed by sudo
+oMSyntax: 22
+lDAPDisplayName: sudoCommand
+name: sudoCommand
+schemaIDGUID:: D6QR4P5UyUen3RGYJCHCPg==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoRunAs,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoRunAs
+distinguishedName: CN=sudoRunAs,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.4
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoRunAs
+adminDescription: User(s) impersonated by sudo (deprecated)
+oMSyntax: 22
+lDAPDisplayName: sudoRunAs
+name: sudoRunAs
+schemaIDGUID:: CP98mCQTyUKKxGrQeM80hQ==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoOption,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoOption
+distinguishedName: CN=sudoOption,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.5
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoOption
+adminDescription: Option(s) followed by sudo
+oMSyntax: 22
+lDAPDisplayName: sudoOption
+name: sudoOption
+schemaIDGUID:: ojaPzBBlAEmsvrHxQctLnA==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoRunAsUser,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoRunAsUser
+distinguishedName: CN=sudoRunAsUser,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.6
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoRunAsUser
+adminDescription: User(s) impersonated by sudo
+oMSyntax: 22
+lDAPDisplayName: sudoRunAsUser
+name: sudoRunAsUser
+schemaIDGUID:: 9C52yPYd3RG3jMR2VtiVkw==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoRunAsGroup,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoRunAsGroup
+distinguishedName: CN=sudoRunAsGroup,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.7
+attributeSyntax: 2.5.5.5
+isSingleValued: FALSE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoRunAsGroup
+adminDescription: Groups(s) impersonated by sudo
+oMSyntax: 22
+lDAPDisplayName: sudoRunAsGroup
+name: sudoRunAsGroup
+schemaIDGUID:: xJhSt/Yd3RGJPTB1VtiVkw==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoNotBefore,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoNotBefore
+distinguishedName: CN=sudoNotBefore,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.8
+attributeSyntax: 2.5.5.11
+isSingleValued: TRUE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoNotBefore
+adminDescription: Start of time interval for which the entry is valid
+oMSyntax: 24
+lDAPDisplayName:  sudoNotBefore
+name: sudoNotBefore
+schemaIDGUID:: dm1HnRfY4RGf4gopYYhwmw==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoNotAfter,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoNotAfter
+distinguishedName: CN=sudoNotAfter,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.9
+attributeSyntax: 2.5.5.11
+isSingleValued: TRUE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoNotAfter
+adminDescription: End of time interval for which the entry is valid
+oMSyntax: 24
+lDAPDisplayName:  sudoNotAfter
+name: sudoNotAfter
+schemaIDGUID:: OAr/pBfY4RG9dBIpYYhwmw==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn: CN=sudoOrder,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: attributeSchema
+cn: sudoOrder
+distinguishedName: CN=sudoOrder,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+attributeID: 1.3.6.1.4.1.15953.9.1.10
+attributeSyntax: 2.5.5.9
+isSingleValued: TRUE
+showInAdvancedViewOnly: TRUE
+adminDisplayName: sudoOrder
+adminDescription: an integer to order the sudoRole entries
+oMSyntax: 2
+lDAPDisplayName:  sudoOrder
+name: sudoOrder
+schemaIDGUID:: 0J8yrRfY4RGIYBUpYYhwmw==
+objectCategory: CN=Attribute-Schema,CN=Schema,CN=Configuration,DC=X
+
+dn:
+changetype: modify
+add: schemaUpdateNow
+schemaUpdateNow: 1
+-
+
+dn: CN=sudoRole,CN=Schema,CN=Configuration,DC=X
+changetype: add
+objectClass: top
+objectClass: classSchema
+cn: sudoRole
+distinguishedName: CN=sudoRole,CN=Schema,CN=Configuration,DC=X
+instanceType: 4
+possSuperiors: container
+possSuperiors: top
+subClassOf: top
+governsID: 1.3.6.1.4.1.15953.9.2.1
+mayContain: sudoCommand
+mayContain: sudoHost
+mayContain: sudoOption
+mayContain: sudoRunAs
+mayContain: sudoRunAsUser
+mayContain: sudoRunAsGroup
+mayContain: sudoUser
+mayContain: sudoNotBefore
+mayContain: sudoNotAfter
+mayContain: sudoOrder
+rDNAttID: cn
+showInAdvancedViewOnly: FALSE
+adminDisplayName: sudoRole
+adminDescription: Sudoer Entries
+objectClassCategory: 1
+lDAPDisplayName: sudoRole
+name: sudoRole
+schemaIDGUID:: SQn432lnZ0+ukbdh3+gN3w==
+systemOnly: FALSE
+objectCategory: CN=Class-Schema,CN=Schema,CN=Configuration,DC=X
+defaultObjectCategory: CN=sudoRole,CN=Schema,CN=Configuration,DC=X

--- a/ansible/roles/win-schema/tasks/main.yml
+++ b/ansible/roles/win-schema/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Copy sudo schema to guest
+  win_copy:
+    src: '{{ item }}.schema'
+    dest: 'C:\{{ item }}.schema'
+  with_items:
+  - sudo
+
+- name: Install additional schemas
+  win_shell: |
+    ldifde -i -f C:\{{ item }}.schema -c dc=X {{ suffix }}
+  register: schema
+  failed_when: schema.rc != 0 and schema.stdout is not search('ENTRY_EXISTS')
+  changed_when: schema.rc == 0
+  with_items:
+  - sudo

--- a/ansible/variables.yml
+++ b/ansible/variables.yml
@@ -1,0 +1,57 @@
+# Network information
+network: {
+  base_ip: 192.168.100,
+  reverse_zone: 100.168.192.in-addr.arpa,
+  dns_tld: vm,
+  dns_server: '192.168.100.10'
+}
+
+# IPA server configuration
+master: {
+  ip: '{{ network.base_ip }}.10',
+  domain: 'ipa.{{ network.dns_tld }}',
+  hostname: 'master',
+  fqn: 'master.ipa.{{ network.dns_tld }}',
+  netbios: 'IPA',
+  password: '123456789'
+}
+
+# AD server configuration
+ad: {
+  ip: '{{ network.base_ip }}.110',
+  domain: 'ad.{{ network.dns_tld }}',
+  hostname: 'root-dc',
+  fqn: 'root-dc.ad.{{ network.dns_tld }}',
+  netbios: 'ADROOT',
+  forest_mode: WinThreshold,
+  domain_mode: WinThreshold,
+  safe_password: Secret123,
+  suffix: 'dc=ad,dc={{ network.dns_tld }}'
+}
+
+# AD child server configuration
+ad_child: {
+  ip: '{{ network.base_ip }}.120',
+  domain: 'child.{{ ad.domain }}',
+  hostname: 'child-dc',
+  fqn: 'child-dc.child.{{ ad.domain }}',
+  netbios: 'ADCHILD',
+  safe_password: Secret123,
+  suffix: 'dc=child,{{ ad.suffix }}'
+}
+
+# Client configuration
+client0: {
+  ip: '{{ network.base_ip }}.30',
+  domain: 'client.{{ network.dns_tld }}',
+  hostname: 'master',
+  fqn: 'master.client.{{ network.dns_tld }}'
+}
+
+# Controller configuration
+controller: {
+  ip: '{{ network.base_ip }}.20',
+  domain: 'ipa.{{ network.dns_tld }}',
+  hostname: 'master',
+  fqn: 'master.controller.{{ network.dns_tld }}',
+}

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -332,3 +332,7 @@ class RunWebuiTests(RunPytest):
         logging.error(
             '>>>>>> WEBUI TESTS FAILED (error code: {code}) <<<<<<'.format(
                 code=self.returncode))
+
+
+class RunADTests(RunPytest):
+    action_name = 'ad'

--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -64,7 +64,8 @@ class VagrantUp(VagrantTask):
 class VagrantProvision(VagrantTask):
     def _run(self):
         self.execute_subtask(
-            PopenTask(['vagrant', 'provision'], timeout=None))
+            PopenTask(['vagrant', 'provision'],
+                      timeout=None))
 
 
 class VagrantCleanup(VagrantTask):

--- a/templates/ad.vars.yml
+++ b/templates/ad.vars.yml
@@ -1,0 +1,3 @@
+---
+repofile_url: {{ repofile_url }}
+update_packages: {{ update_packages }}

--- a/templates/vagrantfiles/Vagrantfile.ad
+++ b/templates/vagrantfiles/Vagrantfile.ad
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+
+Vagrant.configure(2) do |config|
+
+    config.ssh.username = "root"
+
+    config.vm.synced_folder "./", "/vagrant",
+        type: "nfs",
+        nfs_udp: false
+
+    config.vm.box = "{{ vagrant_template_name }}"
+
+    config.vm.provider "libvirt" do |domain, override|
+        # Defaults for masters and replica
+        # WARNING: Do not overcommit CPUs, it causes issues during
+        # provisioning, when RPMs are installed
+        domain.cpus = 1
+        domain.memory = 2750
+
+        # Nested virtualization options
+        domain.nested = true
+        domain.cpu_mode = "host-passthrough"
+
+        # Disable graphics
+        domain.graphics_type = "none"
+
+        domain.volume_cache = "unsafe"
+    end
+
+    config.vm.provision :ansible do |ansible|
+        # Disable default limit to connect to all the machines
+        ansible.limit = "all"
+        ansible.playbook = "../../ansible/provision_ad.yml"
+        ansible.extra_vars = "vars.yml"
+        ansible.host_vars = {
+            "ad" => {"ansible_winrm_server_cert_validation" => "ignore"},
+            "ad-child" => {"ansible_winrm_server_cert_validation" => "ignore"}
+        }
+    end
+
+    config.vm.define "controller" , primary: true do |controller|
+        controller.vm.network "private_network", ip: "192.168.100.20"
+        controller.vm.provider "libvirt" do |domain,override|
+            # Less resources needed for controller
+            domain.memory = 950
+        end
+    end
+
+    config.vm.define "ad" do |ad|
+        ad.vm.box = "sssd-winsrv2019-ad"
+        ad.vm.box_url = "http://download.eng.brq.redhat.com/archive/sssd/vagrant/sssd-winsrv2019-ad.json"
+        ad.vm.hostname = "root-dc"
+        ad.vm.network "private_network", ip:"192.168.100.110"
+        # Disable NFS sharing (==> default: Mounting NFS shared folders...)
+        ad.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
+    end
+
+    config.vm.define "ad-child" do |adchild|
+        adchild.vm.box = "sssd-winsrv2019-ad-child"
+        adchild.vm.box_url = "http://download.eng.brq.redhat.com/archive/sssd/vagrant/sssd-winsrv2019-ad-child.json"
+        adchild.vm.hostname = "child-dc"
+        adchild.vm.network "private_network", ip:"192.168.100.120"
+        # Disable NFS sharing (==> default: Mounting NFS shared folders...)
+        adchild.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
+    end
+
+    config.vm.define "master" do |master|
+        # master.vm.box = "{{ vagrant_template_name }}"
+        master.vm.hostname = "master.ipa.vm"
+        master.vm.network "private_network", ip: "192.168.100.10"
+    end
+
+    config.vm.define "client0"  do |client0|
+        # client0.vm.box = "{{ vagrant_template_name }}"
+        client0.vm.hostname = "master.client.vm"
+        client0.vm.network "private_network", ip: "192.168.100.30"
+        client0.vm.provider "libvirt" do |domain,override|
+            domain.memory = 950
+        end
+    end
+
+end
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')


### PR DESCRIPTION
This commit implements new "provision_ad.yml" ansible playbook and new roles
such as packages, win-common, win-dns, win-domain, win-forest, win-ping, and
win-shcema. A new class "RunADTests" has been implemented to execute AD test
suites, and a new vagrant file "Vagrantfile.ad" defines the AD cluster, which
is composed by controller, ad, ad-child, master, and client0 VMs.

The implementation is based on three steps: a) prci deploy changes (new
packages and dependencies requirements, such as winrm modules), b) vagrant
cluster (using well-defined images for both Linux and Windows machines), and
c) software provisioning (software, schemas, the configuration of the scenario)