### PR TITLE
Stop prci systemd service when unable to publish artifacts

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -4,6 +4,7 @@ import shutil
 import socket
 import urllib
 import uuid
+import subprocess
 
 from .ansible import AnsiblePlaybook
 from .common import (FallibleTask, TaskException, PopenTask,
@@ -112,6 +113,7 @@ class JobTask(FallibleTask):
             logging.debug(exc, exc_info=True)
             hostname = socket.gethostname().split('.')[0] # don't leak fqdn
             msg = 'Failed to publish artifacts from {}'.format(hostname)
+            subprocess.run(['systemctl', 'stop', 'prci'], timeout=120)
             raise TaskException(self, msg)
         else:
             self.remote_url = urllib.parse.urljoin(


### PR DESCRIPTION
PR-CI publish artifacts fails when the runner gets out of space, but the systemd service
keeps running. This causes the next scheduled jobs to fail with the same reason. With this
commit, prci systemd service is disabled to avoid causing more troubles.