### PR TITLE
Change version suffix from test to .dev

### DIFF
--- a/ansible/roles/builder/build/tasks/generate_build_version.yml
+++ b/ansible/roles/builder/build/tasks/generate_build_version.yml
@@ -26,8 +26,8 @@
 
 - name: set pre_release version
   shell: |
-    sed 's/^define(IPA_VERSION_PRE_RELEASE, .*/define(IPA_VERSION_PRE_RELEASE, test)/' -i /root/freeipa/VERSION.m4
+    sed 's/^define(IPA_VERSION_PRE_RELEASE, .*/define(IPA_VERSION_PRE_RELEASE, .dev)/' -i /root/freeipa/VERSION.m4
 
 - name: create version
   set_fact:
-    build_version: "{{ major.stdout }}.{{ minor.stdout }}.{{ release.stdout }}test"
+    build_version: "{{ major.stdout }}.{{ minor.stdout }}.{{ release.stdout }}.dev"


### PR DESCRIPTION
FreeIPA uses PEP-440 compliant version parsing. This spec has few
asumptions about about version structure. As result, 4.7.90test is lower
than 4.7.2. However, 4.7.90.dev is higher than 4.7.2.

Replica deployment code does verify that a replica is deployed against a
server that it at least the same or older than the replica itself. With
4.7.90test, replica never could be newer than 4.7.2 and thus the test is
failing.

Change the version used by the PR CI to comply with PEP-440.