### PR TITLE
use @pki/master copr for f30

### DIFF
--- a/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
@@ -78,4 +78,15 @@ gpgkey=https://copr-be.cloud.fedoraproject.org/results/@pki/10.6-nightly/pubkey.
 repo_gpgcheck=0
 enabled={{ repo_pki_testing_enabled }}
 enabled_metadata=1
+
+[group_pki-master]
+name=Copr repo for master owned by @pki
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/master/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/@pki/master/pubkey.gpg
+repo_gpgcheck=0
+enabled={{ repo_pki_master_enabled }}
+enabled_metadata=1
 """

--- a/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
@@ -51,4 +51,15 @@ name=rawhide
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=$basearch
 failovermethod=priority
 enabled={{ repo_rawhide_enabled }}
+
+[group_pki-master]
+name=Copr repo for master owned by @pki
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/master/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/@pki/master/pubkey.gpg
+repo_gpgcheck=0
+enabled={{ repo_pki_master_enabled }}
+enabled_metadata=1
 """

--- a/ansible/vars/fedora/27.yml
+++ b/ansible/vars/fedora/27.yml
@@ -7,3 +7,4 @@ repo_updates_enabled: 1
 repo_updates_testing_enabled: 0
 repo_freeipa_copr_enabled: 1
 repo_pki_testing_enabled: 0
+repo_pki_master_enabled: 0

--- a/ansible/vars/fedora/28.yml
+++ b/ansible/vars/fedora/28.yml
@@ -7,3 +7,4 @@ repo_updates_enabled: 1
 repo_updates_testing_enabled: 0
 repo_freeipa_copr_enabled: 1
 repo_pki_testing_enabled: 0
+repo_pki_master_enabled: 0

--- a/ansible/vars/fedora/29.yml
+++ b/ansible/vars/fedora/29.yml
@@ -7,3 +7,4 @@ repo_updates_enabled: 1
 repo_updates_testing_enabled: 1
 repo_freeipa_copr_enabled: 1
 repo_pki_testing_enabled: 1
+repo_pki_master_enabled: 0

--- a/ansible/vars/fedora/30.yml
+++ b/ansible/vars/fedora/30.yml
@@ -6,4 +6,5 @@ repo_fedora_enabled: 1
 repo_updates_enabled: 1
 repo_updates_testing_enabled: 1
 repo_freeipa_copr_enabled: 1
-repo_pki_testing_enabled: 1
+repo_pki_testing_enabled: 0
+repo_pki_master_enabled: 1

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -7,5 +7,6 @@ base_box_url: "file://{{ fedora_rawhide_template_dir }}/latest.box"
 fedora_rawhide_images_remote_dir: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/x86_64/images/
 
 repo_rawhide_enabled: 1
-repo_freeipa_copr_enabled: 0
+repo_freeipa_copr_enabled: 1
 repo_pki_testing_enabled: 0
+repo_pki_master_enabled: 1


### PR DESCRIPTION
FreeIPA master now requires Dogtag 10.7.  The @pki/10.6-nightly COPR
is not even built for f30, let alone with pki-10.7 packages.  Use
the @pki/master COPR on f30 to pull in the latest Dogtag builds.

(This if my first pr-ci PR... do images have to be explicitly rebuilt
after a change like this gets merged, or does it happen automagically?)