### PR TITLE
Fixes Orphan Vagrant Processes and Fix Orphan Vms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ ansible/vault-password
 # Python
 *.py[cod]
 __pycache__/
+.mypy_cache
 
 # Emacs
 *~
+
+# VScode
+.vscode


### PR DESCRIPTION
This PR introduces a way to clean orphans from a SIGKILL sent by kernel and a bad handled SIGTERM:

- First, ensure there is no orphan `vagrant up` remaining in RAM. vagrant up tends to timeout after some time, but this timeout is up to minutes, then we force a kill in any running process;
- Second, destroy all vagrant vms before starting the new prci instance. Since we can't handle SIGKILL, the best way to separate the responsibility from autocleaner ( autocleaner don't know now if prci is running, and if the instances running are part of actual run of prci or previous run ).