### PR TITLE
Replace journald.conf setting used to control file size limit

### DIFF
--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -110,6 +110,6 @@
 - name: configure size of systemd journal
   lineinfile:
     path: /etc/systemd/journald.conf
-    regexp: '^#?SystemMaxFileSize'
-    line: 'SystemMaxFileSize={{ limit_size_systemd_journal }}'
+    regexp: '^#?SystemMaxUse'
+    line: 'SystemMaxUse={{ limit_size_systemd_journal }}'
     state: present


### PR DESCRIPTION
SystemMaxFileSize controls how large individual journal files may
grow at most; while SystemMaxUse controls how much disk space the
journal may use up at most. The latter is a better fit given the
storage availability PR-CI currently has in its runners.

Signed-off-by: Armando Neto <abiagion@redhat.com>