### PR TITLE
Increase time between requests

### DIFF
--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -168,7 +168,7 @@ class World(object):
         self, pr_number: int, task_name: Text
     ) -> "Status":
         """Gets commit status on GitHub using GraphQL API"""
-        sleep(randint(3, 8))  # FIXME: We're polling too concurrently
+        sleep(randint(8, 13))  # FIXME: We're polling too concurrently
         pr_query = queries.make_pull_request_query(
             self.repo_owner, self.repo_name, pr_number
         )

--- a/github/prci.py
+++ b/github/prci.py
@@ -6,6 +6,7 @@ import logging.config
 import signal
 import sys
 from functools import partial
+from random import randint
 from time import sleep
 from typing import Dict, Iterator, Optional, Text
 
@@ -238,7 +239,7 @@ def main():
     repo = config["repository"]
     tasks_path = config["tasks_file"]
     whitelist = config["whitelist"]
-    no_task_backoff_time = config["no_task_backoff_time"]
+    no_task_backoff_time = config["no_task_backoff_time"] + randint(1, 30)
 
     logging.config.dictConfig(config["logging"])
 


### PR DESCRIPTION
- Increase sleep time between status requests.
- Add a random component to back-off time to reduce concurrent requests by multiple runners.

Signed-off-by: Armando Neto <abiagion@redhat.com>