### PR TITLE
Re-schedule ipa-4-6 nightly regression

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -39,7 +39,7 @@ nightly_jobs:
     prci_config: "nightly_master.yaml"
   - name: testing_ipa-4.6
     weekdays: "7"
-    hour: "10"
+    hour: "15"
     minute: "00"
     flow: "ci"
     branch: "ipa-4-6"


### PR DESCRIPTION
Both nightly regressions ipa-4-6 and ipa-4-7 are running at the same time. This
is causing "Unable to create '/root/openclose_pr/freeipa/.git/index.lock': File exists
issues. This commit re-schedule ipa-4-6 nightly regression execution to a different slot.