### PR TITLE
Whitelist: add ssidhaye

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -43,6 +43,7 @@
 - slaykovsky
 - stlaz
 - stanislavlevin
+- ssidhaye
 - sumit-bose
 - t-woerner
 - tbordaz


### PR DESCRIPTION
In order to run PR-CI, Sumedh Sidhaye needs to be defined in
the whitelist.