### PR TITLE
Delete folders for jobs older than 3 days

### DIFF
--- a/ansible/roles/runner/tasks/autocleaner.yml
+++ b/ansible/roles/runner/tasks/autocleaner.yml
@@ -4,6 +4,6 @@
     minute: "0"
     hour: "15"
     weekday: "7"
-    job: python3 /root/freeipa-pr-ci/autocleaner.py
+    job: python3 /root/freeipa-pr-ci/autocleaner.py --jobs_dir_exp 3
     user: root
     state: present


### PR DESCRIPTION
Runners are hitting 'out-of-space' issue. Something between 2 and 7GB are stored weekly.