### PR TITLE
Clear global journalctl as part of autocleaner

### DIFF
--- a/ansible/roles/runner/tasks/autocleaner.yml
+++ b/ansible/roles/runner/tasks/autocleaner.yml
@@ -2,8 +2,7 @@
   cron:
     name: "PRCI autocleaner"
     minute: "0"
-    hour: "15"
-    weekday: "7"
+    hour: "7"
     job: python3 /root/freeipa-pr-ci/autocleaner.py --jobs_dir_exp 3
     user: root
     state: present

--- a/autocleaner.py
+++ b/autocleaner.py
@@ -66,6 +66,13 @@ def stop_prci():
     subprocess.run(['systemctl', 'stop', 'prci'], timeout=TIMEOUT)
 
 
+def clear_journalctl():
+    """
+    Clear journalctl
+    """
+    subprocess.run(['journalctl', '--vacuum-time=2d'], timeout=TIMEOUT)
+
+
 def status_prci():
     """
     Check PRCI systemd service status
@@ -401,6 +408,8 @@ def main():
             if not is_qemu_running():
                 logger.info('PRCI not active, stopping systemd service...')
                 stop_prci()
+                logger.info('Clearing journalctl, retain the past two days...')
+                clear_journalctl()
                 logger.info('PRCI service stopped...')
                 logger.info('Started auto-cleaning process...')
                 cleaning_process = Process(target=run, args=(args,))


### PR DESCRIPTION
Based on our observations, journalctl logs keep growing until there
is no space left in the runner. This commit adds a function to
autocleaner script to clear journalctl logs and retain only the past
two days.

This commit also increases the autocleaner frequency to be executed
every day at 7am CET time.