### PR TITLE
Whitelist: add rjeffman

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -38,6 +38,7 @@
 - pvomacka
 - rcritten
 - Rezney
+- rjeffman
 - serg-cymbaluk
 - simo5
 - slaykovsky


### PR DESCRIPTION
In order to run PR-CI, Rafael Guterres needs to be defined in the whitelist (https://github.com/rjeffman).