### PR TITLE
Use freeipa account to store Windows boxes

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -56,7 +56,7 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.define "ad-root" do |ad_root|
-        ad_root.vm.box = "peru/windows-server-2016-standard-x64-eval"
+        ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
         ad_root.vm.hostname = "ad-root"
         ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -56,7 +56,7 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.define "ad-root" do |ad_root|
-        ad_root.vm.box = "peru/windows-server-2016-standard-x64-eval"
+        ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
         ad_root.vm.hostname = "ad-root"
         ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true


### PR DESCRIPTION
This way all versions used by PR-CI can be hosted, older or recent ones.

Latest image working: https://app.vagrantup.com/freeipa/boxes/windows-server-2016-standard-x64-eval/versions/20190801.01

Signed-off-by: Armando Neto <abiagion@redhat.com>