### PR TITLE
Set git user.name config to fix openclose_pr_tool

### DIFF
--- a/ansible/roles/automation/setup/tasks/setup.yml
+++ b/ansible/roles/automation/setup/tasks/setup.yml
@@ -94,6 +94,12 @@
     repo: "{{ pr_ci_repo }}"
     force: true
 
+- name: Fix git user.email
+  git_config:
+    name: user.email
+    scope: global
+    value: "root@{{ ansible_fqdn }}"
+
 - name: clone freeipa fork
   git:
     repo: "git@github_pr_tool:{{ repo_owner }}/freeipa.git"


### PR DESCRIPTION
Add missing configuration to git fixing pull request creation.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/313

Signed-off-by: Armando Neto <abiagion@redhat.com>