### PR TITLE
Remove DNF warning and add retry when installing ipa* packages

### DIFF
--- a/ansible/roles/automation/setup/tasks/setup.yml
+++ b/ansible/roles/automation/setup/tasks/setup.yml
@@ -1,20 +1,19 @@
 ---
 - name: install packages dependencies
   dnf:
-    name: "{{ item }}"
     state: present
-  with_items:
-    - python3-github3py
-    - PyYAML
-    - git
-    - crontabs
-    - python2-tqdm
-    - ansible
-    - vagrant
-    - libvirt
-    - vagrant-libvirt
-    - rsync
-    - libguestfs-tools-c  # required for vagrant package command
+    name:
+      - python3-github3py
+      - PyYAML
+      - git
+      - crontabs
+      - python2-tqdm
+      - ansible
+      - vagrant
+      - libvirt
+      - vagrant-libvirt
+      - rsync
+      - libguestfs-tools-c  # required for vagrant package command
 
 - name: install pip dependencies
   pip:

--- a/ansible/roles/builder/prepare/tasks/main.yml
+++ b/ansible/roles/builder/prepare/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 - name: install packages for builder role
   dnf:
-    name: "{{ item }}"
     state: latest
-  with_items:
-    - mock
-    - git
+    name:
+      - mock
+      - git
 
 - name: set default mock config
   template:

--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -32,6 +32,10 @@
         name:
           - freeipa-*
           - python*-ipatests
+      register: result
+      until: result.rc == 0
+      retries: 3
+      delay: 5
   rescue:
     # Distro repos are turned off in default template
     # If a new package from fedora/updates is required, this will fix it

--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -28,21 +28,19 @@
 - name: install freeipa packages
   block:
     - dnf:
-        name: "{{ item }}"
         state: latest
-      with_items:
-        - freeipa-*
-        - python*-ipatests
+        name:
+          - freeipa-*
+          - python*-ipatests
   rescue:
     # Distro repos are turned off in default template
     # If a new package from fedora/updates is required, this will fix it
     - dnf:
-        name: "{{ item }}"
         state: latest
         enablerepo: fedora,updates
-      with_items:
-        - freeipa-*
-        - python*-ipatests
+        name:
+          - freeipa-*
+          - python*-ipatests
 
 - name: install client packages
   dnf:

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -45,17 +45,16 @@
 
 - name: install additional packages
   dnf:
-    name: "{{ item }}"
     state: latest
-  with_items:
-    - PyYAML  # ipa-vagrant-ci dependency
-    - vim
-    - NetworkManager
-    - xorg-x11-server-Xvfb
-    - firefox
-    - python3-paramiko
-    - firewalld
-    - nfs-utils
+    name:
+      - PyYAML  # ipa-vagrant-ci dependency
+      - vim
+      - NetworkManager
+      - xorg-x11-server-Xvfb
+      - firefox
+      - python3-paramiko
+      - firewalld
+      - nfs-utils
 
 - name: install Ansible dependencies
   dnf:

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -17,36 +17,35 @@
 
 - name: install runner dependencies
   dnf:
-    name: "{{ item }}"
     state: present
-  with_items:
-    - tuned
-    - vagrant
-    - vagrant-sshfs
-    - vagrant-libvirt
-    - libguestfs-tools-c  # required for vagrant package command
-    - ansible  # TODO requires >= 2.3
-    - nfs-utils
-    - git
-    - libvirt
-    - libvirt-devel
-    - ruby-devel
-    - rsync
-    - createrepo
-    - gzip
-    - gcc
-    - python3-devel
-    - python3-pip
-    - python3-winrm
-    - python2-winrm
-    - python3-netaddr
-    - python2-netaddr
-    - python2-requests
-    - python3-requests
-    - NetworkManager
-    - python-dnf
-    - redhat-rpm-config
-    - crontabs
+    name:
+      - tuned
+      - vagrant
+      - vagrant-sshfs
+      - vagrant-libvirt
+      - libguestfs-tools-c  # required for vagrant package command
+      - ansible  # TODO requires >= 2.3
+      - nfs-utils
+      - git
+      - libvirt
+      - libvirt-devel
+      - ruby-devel
+      - rsync
+      - createrepo
+      - gzip
+      - gcc
+      - python3-devel
+      - python3-pip
+      - python3-winrm
+      - python2-winrm
+      - python3-netaddr
+      - python2-netaddr
+      - python2-requests
+      - python3-requests
+      - NetworkManager
+      - python-dnf
+      - redhat-rpm-config
+      - crontabs
   notify:
     - restart_nfs
 


### PR DESCRIPTION
Changes:
- Replace dnf task to use loops instead of with_items
- Retry dnf tasks to fix repository synchronization issues 

---

These changes fix the following deprecation warning:
```
[DEPRECATION WARNING]: Invoking "dnf" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['freeipa-*',
'python*-ipatests']` and remove the loop. This feature will be removed in
version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

More info: https://docs.ansible.com/ansible/latest/modules/dnf_module.html

Issue: #295

---

When installing packages we might encounter a temporary network issue or fedora repo may fail to respond to dnf in time; this will result in errors like this:

```
failed: [controller] (item=[u'freeipa-*', u'python*-ipatests']) => {"changed": false, "item": ["freeipa-*", "python*-ipatests"], "msg": "Failed to synchronize cache for repo 'updates-testing'", "rc": 1, "results": []}
```

Retrying dnf tasks can reduce the chance of failures when executing jobs.

---

PR used to test these changes: https://github.com/netoarmando/freeipa/pull/20