### PR TITLE
Send cron output to system log

### DIFF
--- a/ansible/roles/automation/setup/tasks/setup.yml
+++ b/ansible/roles/automation/setup/tasks/setup.yml
@@ -121,3 +121,15 @@
   with_items:
     - virtlogd
     - libvirtd
+
+- name: enable cron journals
+  lineinfile:
+    path: /etc/sysconfig/crond
+    regexp: '^CRONDARGS='
+    line: CRONDARGS=-s
+
+- name: restart cron service
+  service:
+    name: crond
+    enabled: true
+    state: restarted


### PR DESCRIPTION
Enable cron's option to direct Cron to send the job output to the system log using syslog(3).

The results should be accessible by executing `journalctl -ft CROND`.

Signed-off-by: Armando Neto <abiagion@redhat.com>