### PR TITLE
Support Fedora 30 runners + other changes

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -26,25 +26,15 @@
   when: update_packages is defined and update_packages
 
 - name: install freeipa packages
-  block:
-    - dnf:
-        state: latest
-        name:
-          - freeipa-*
-          - python*-ipatests
-      register: result
-      until: result.rc == 0
-      retries: 3
-      delay: 5
-  rescue:
-    # Distro repos are turned off in default template
-    # If a new package from fedora/updates is required, this will fix it
-    - dnf:
-        state: latest
-        enablerepo: fedora,updates
-        name:
-          - freeipa-*
-          - python*-ipatests
+  dnf:
+    state: latest
+    name:
+      - freeipa-*
+      - python*-ipatests
+  register: result
+  until: result.rc == 0
+  retries: 3
+  delay: 5
 
 - name: install client packages
   dnf:

--- a/ansible/roles/runner/handlers/main.yml
+++ b/ansible/roles/runner/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: restart_nfs
   service:
-    name: nfs
+    name: nfs-server
     state: restarted

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -43,11 +43,15 @@
       - python2-requests
       - python3-requests
       - NetworkManager
-      - python-dnf
+      - python3-dnf
       - redhat-rpm-config
       - crontabs
   notify:
     - restart_nfs
+
+- name: register vagrant version
+  shell: vagrant --version | awk '{print $2}'
+  register: vagrant_version
 
 # as per sssd-suite readme file states, we need vagrant plugins...
 - name: install libvirt plugin for vagrant
@@ -56,14 +60,17 @@
 
 - name: install vagrant plugin (winrm) for AD tests
   raw: vagrant plugin install winrm
+  when: vagrant_version.stdout is version('2.2.0', '<')
   ignore_errors: yes
 
 - name: install vagrant plugins (winrm-fs) for AD tests
   raw: vagrant plugin install winrm-fs
+  when: vagrant_version.stdout is version('2.2.0', '<')
   ignore_errors: yes
 
 - name: install vagrant plugins (winrm-elevated) for AD tests
   raw: vagrant plugin install winrm-elevated
+  when: vagrant_version.stdout is version('2.2.0', '<')
   ignore_errors: yes
 
 # adding after packages install as the file can be overwritten by "mailcap"
@@ -84,7 +91,7 @@
 
 - name: start&enable nfs
   service:
-    name: nfs
+    name: nfs-server
     enabled: true
     state: started
 

--- a/autocleaner.py
+++ b/autocleaner.py
@@ -89,7 +89,7 @@ def load_yaml(yml_path):
     yaml = ruamel.yaml.YAML()
     try:
         with open(yml_path) as yml_file:
-            return yaml.load(yml_file)
+            return yaml.safe_load(yml_file)
     except IOError as exc:
         logger.error('Failed to open %s: %s', yml_path, exc)
         sys.exit(1)
@@ -267,7 +267,7 @@ class PRCIDef():
         Get template name and version
         """
         yaml = ruamel.yaml.YAML()
-        templ_dict = self.get_templ_list(yaml.load(yaml_data))
+        templ_dict = self.get_templ_list(yaml.safe_load(yaml_data))
         templ_name = templ_dict['name']
         templ_ver = templ_dict['version']
         return templ_name, templ_ver

--- a/github/internals/entities.py
+++ b/github/internals/entities.py
@@ -497,10 +497,10 @@ class PullRequest(object):
         tasks_file_content = self.__get_tasks_file_content(world)
 
         try:
-            return yaml.load(tasks_file_content)["jobs"]
+            return yaml.safe_load(tasks_file_content)["jobs"]
         # FIXME: for older PRs to pass. Can be later deleted
         except KeyError:
-            return yaml.load(task_link)["jobs"]
+            return yaml.safe_load(task_link)["jobs"]
 
     def __remove_label(self, world: World, label: Label) -> None:
         """Removes PR's label on GitHub using REST API

--- a/github/open_close_pr.py
+++ b/github/open_close_pr.py
@@ -36,7 +36,7 @@ def load_yaml(yml_path):
     yaml = ruamel.yaml.YAML()
     try:
         with open(yml_path, 'r+') as yml_file:
-            return yaml.load(yml_file)
+            return yaml.safe_load(yml_file)
     except IOError as exc:
         raise argparse.ArgumentTypeError(
             'Failed to open {}: {}'.format(yml_path, exc))

--- a/github/prci.py
+++ b/github/prci.py
@@ -43,7 +43,7 @@ def create_parser():
         def load_yaml(yml_path):
             try:
                 with open(yml_path) as yml_file:
-                    return yaml.load(yml_file)
+                    return yaml.safe_load(yml_file)
             except IOError as e:
                 raise argparse.ArgumentTypeError(
                     'Failed to open {}: {}'.format(yml_path, e))

--- a/scripts/prci_test_control.py
+++ b/scripts/prci_test_control.py
@@ -47,7 +47,7 @@ class TestControl(object):
 
     def __init__(self, cfg_path):
         try:
-            cfg = yaml.load(open(cfg_path))
+            cfg = yaml.safe_load(open(cfg_path))
         except (IOError, yaml.parser.ParserError) as exc:
             raise ValueError(exc)
 

--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -71,5 +71,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -83,5 +83,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -36,5 +36,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -39,5 +39,3 @@ Vagrant.configure(2) do |config|
         end
     end
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -60,5 +60,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -47,12 +47,6 @@ Vagrant.configure(2) do |config|
 
 
     config.vm.define "master"  do |master|
-        # FIXME: This is strictly a temporary change for debugging purposes
-        # https://pagure.io/freeipa/issue/7165
-        # Added by mreznik's request
-        master.vm.provider "libvirt" do |domain,override|
-            domain.cpus = 2
-        end
     end
 
 

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -57,5 +57,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -60,5 +60,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_3client
+++ b/templates/vagrantfiles/Vagrantfile.master_3client
@@ -66,5 +66,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -63,5 +63,3 @@ Vagrant.configure(2) do |config|
     end
 
 end
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')


### PR DESCRIPTION
Changes required to provision PR-CI Fedora 30 runners and some other fixes.

## Fix yaml loader

Replace method used to load yaml file.

Method `yaml.load()` was deprecated, more info:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

## Remove repo fallback

New templates have the required repositories configured properly and
this fallback is no longer needed.

This replaces the original PR https://github.com/freeipa/freeipa-pr-ci/pull/140

## Revert "templates: increase CPUs on master to 2"

This reverts commit ddeb09a.
It was introduced as a temporary change for testing/debugging.

This is replacing original PR: https://github.com/freeipa/freeipa-pr-ci/pull/121

## Remove vagrant cloud url

After https://github.com/hashicorp/vagrant/commit/f2bf18e56be36ed4bfbfe42fe20ab9147910ab3f
this variable can't be replaced.

This was added in the past, since latest vagrant version for Fedora 28
is 2.0.2 we don't need to have that line anymore.

According to this https://groups.google.com/forum/#!msg/vagrant-up/H8C68UTkosU/qz4YUmAgBAAJ
any vagrant version lower than 1.9.6 was required to include that
as a workaround.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/275

## Install and manage services to support fedora 28 and 30

This checks the version on vagrant installed to verify if plug-ins must
be installed.

It also fixes the python version of dnf library to be installed and the
name of nfs-server service.

# Notes
- Tested on a fresh Fedora 28 host to make sure it won't break current hosts. ([build](http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/1eae690e-10ab-11ea-a0f5-525400d2610f/) and [task](http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/bd637912-10ac-11ea-a0f5-525400d2610f/) results)
- Tested on a Fedora 30 host. ([build](http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/ef593df0-10c3-11ea-b637-525400cdd12d) and [task](http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/310457b4-10c7-11ea-b637-525400cdd12d) results)
