### PR TITLE
Handle cascaded termination of vagrant processes

### DIFF
--- a/ansible/roles/runner/files/prci.service
+++ b/ansible/roles/runner/files/prci.service
@@ -12,7 +12,7 @@ ExecStart=/bin/bash -c 'PYTHONPATH=$PYTHONPATH:/root/freeipa-pr-ci /root/freeipa
 StandardOutput=syslog
 StandardError=syslog
 Restart=on-failure
-RestartSec=10m
+RestartSec=3m
 
 [Install]
 WantedBy=multi-user.target

--- a/github/prci.py
+++ b/github/prci.py
@@ -19,6 +19,7 @@ from internals.entities import (
     sentry_report_exception, JobYAMLError
 )
 from internals.gql import util, queries
+from tasks.common import destroy_libvirt_domains
 
 
 logger = logging.getLogger(__name__)
@@ -263,6 +264,7 @@ def main():
     )
 
     while not exit_handler.done:
+        logger.info("Checking pending pull requests.")
         world.check_graphql_limit()
 
         try:
@@ -305,6 +307,8 @@ def main():
                 finally:
                     exit_handler.unregister_task()
                     world.available_resources.give(task)
+                    # Make sure every vm is destroyed
+                    destroy_libvirt_domains()
                     logger.info(
                         "Available resources: %s", world.available_resources
                     )

--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -5,8 +5,7 @@ import time
 
 from . import constants
 from .common import (
-    PopenTask, PopenException, FallibleTask, TaskException,
-    kill_vagrant_processes, kill_vagrant_vms
+    PopenTask, PopenException, FallibleTask, TaskException
 )
 
 
@@ -91,25 +90,9 @@ class VagrantProvision(VagrantTask):
 
 class VagrantCleanup(VagrantTask):
     def _run(self):
-        try:
-            self.execute_subtask(
-                PopenTask(['vagrant', 'destroy']))
-        except PopenException:
-            # First kill all stuck Vagrant processes
-            kill_vagrant_processes()
-
-            # Then restart libvirt daemon
-            self.execute_subtask(
-                PopenTask(['systemctl', 'restart', 'libvirtd'],
-                          raise_on_err=False))
-
-            # Then remove all VMs related to tests
-            kill_vagrant_vms()
-
-            # End finally remove all the images instances
-            self.execute_subtask(
-                PopenTask(['vagrant', 'destroy'], raise_on_err=False))
-
+        logging.info("Destroying vagrant machines.")
+        self.execute_subtask(
+            PopenTask(["vagrant", "destroy"], raise_on_err=False))
 
 class VagrantBoxDownload(VagrantTask):
     def __init__(self, box_name, box_version, link_image=True, **kwargs):


### PR DESCRIPTION
Issue: https://github.com/freeipa/freeipa-pr-ci/issues/309

A first attempt to fix this was done in bd3c3b3b874572b6f396c17c3b70032a6f242cb0 (https://github.com/freeipa/freeipa-pr-ci/pull/206).

Vagrant processes were killed before `VagrantCleanup` and `CloudUpload` had finished, causing more errors.

This commit removes the problematic call to kill vagrant processes and call libvirt to make sure all vms were destroyed and their storage deleted.

This also decreases the delay before the service gets restarted in case of an error.

Signed-off-by: Armando Neto <abiagion@redhat.com>

---

#### Test output:
http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/f266cbbc-f399-11e9-96c7-52540048449e/runner.log.gz
After publishing that output the runner continued to log locally:
```
Oct 20 21:34:25 fedora28.local bash[11869]: 2019-10-20 21:34:25,557 root.upload_artifacts +135: INFO     INFO: root: Job published at: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/f266cbbc-f399-11e9-96c7-52540048449e
Oct 20 21:34:25 fedora28.local bash[11869]: 2019-10-20 21:34:25,557 root.__call__ +127: DEBUG    DEBUG: root: RunPytest timed out after 240s
Oct 20 21:34:25 fedora28.local bash[11869]: Traceback (most recent call last):
Oct 20 21:34:25 fedora28.local bash[11869]:   File "/root/freeipa-pr-ci/tasks/common.py", line 124, in __call__
Oct 20 21:34:25 fedora28.local bash[11869]:     super(FallibleTask, self).__call__()
Oct 20 21:34:25 fedora28.local bash[11869]:   File "/root/freeipa-pr-ci/tasks/common.py", line 108, in __call__
Oct 20 21:34:25 fedora28.local bash[11869]:     raise TimeoutException(self)
Oct 20 21:34:25 fedora28.local bash[11869]: tasks.common.TimeoutException: RunPytest timed out after 240s
Oct 20 21:34:25 fedora28.local bash[11869]: 2019-10-20 21:34:25,558 raven.base.Client.set_dsn +272: DEBUG    DEBUG: raven.base.Client: Configuring Raven for host: https://sentry.io
Oct 20 21:34:25 fedora28.local bash[11869]: 2019-10-20 21:34:25,565 raven.base.Client.send_remote +726: DEBUG    DEBUG: raven.base.Client: Sending message of length 1418 to https://sentry.io/api/193222/store/
Oct 20 21:34:39 fedora28.local bash[11869]: 2019-10-20 21:34:39,783 root.destroy_libvirt_domains +259: INFO     INFO: root: Destroying all libvirt domains.
Oct 20 21:34:39 fedora28.local bash[11869]: 2019-10-20 21:34:39,827 __main__.main +313: INFO     INFO: __main__: Available resources: 4 CPU, 7438.0234375MB
Oct 20 21:35:38 fedora28.local bash[11869]: 2019-10-20 21:35:38,860 __main__.main +267: INFO     INFO: __main__: Checking pending pull requests.
```
Results were published even after the error. We can also see that it tried to destroy all libvirt domains.
