### PR TITLE
Enable swap on runners and virtual machines

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -78,3 +78,7 @@
 # workaround for https://github.com/ansible/ansible/issues/19814
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.ipa.test"
+
+- include_role:
+    name: utils
+    tasks_from: enable_swap

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -12,3 +12,7 @@
 - include: deploy_pr_ci.yml
 - include: autocleaner.yml
   when: activate_autocleaner
+
+- include_role:
+    name: utils
+    tasks_from: enable_swap

--- a/ansible/roles/utils/defaults/main.yml
+++ b/ansible/roles/utils/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+swapfile_size: 1G
+swapfile_file: /swapfile

--- a/ansible/roles/utils/tasks/enable_swap.yml
+++ b/ansible/roles/utils/tasks/enable_swap.yml
@@ -1,0 +1,41 @@
+---
+- block:
+  - name: write swap file
+    command: >
+      fallocate -l {{ swapfile_size }} {{ swapfile_file }}
+    args:
+      creates: "{{ swapfile_file }}"
+      warn: false
+    register: write_swap_file
+
+  - name: set swap file permissions
+    file:
+      path: "{{ swapfile_file }}"
+      owner: root
+      group: root
+      mode: 0600
+
+  - name: create swap file
+    command: >
+      mkswap {{ swapfile_file }}
+    args:
+      warn: false
+    when: write_swap_file is changed
+    register: create_swap_file
+
+  - name: enable swapfile
+    command: >
+      swapon {{ swapfile_file }}
+    args:
+      warn: false
+    when: create_swap_file is changed
+
+  - name: add swapfile to /etc/fstab
+    mount:
+      name: none
+      src: "{{ swapfile_file }}"
+      fstype: swap
+      opts: sw
+      passno: '0'
+      dump: '0'
+      state: present


### PR DESCRIPTION
Enabling swap on both runners and vm might reduce some errors, even when the memory is enough to execute the tasks.

This commit adds a shared role to be used by playbooks during vm provisioning and runners deployment.

All tasks are idempotent operations.
Entry added to fstab to support host restarts.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/288

Signed-off-by: Armando Neto <abiagion@redhat.com>