### PR TITLE
Add fedora 31 box settings

### DIFF
--- a/ansible/roles/box/package/tasks/main.yml
+++ b/ansible/roles/box/package/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: destroy template VM
   become: true
-  shell: vagrant destroy
+  shell: vagrant destroy -f
   args:
     chdir: "{{ template_box_dir }}"
 

--- a/ansible/roles/box/prepare/tasks/cleanup.yml
+++ b/ansible/roles/box/prepare/tasks/cleanup.yml
@@ -6,7 +6,7 @@
 
 - name: destroy vagrant image
   become: true
-  shell: vagrant destroy
+  shell: vagrant destroy -f
   args:
     chdir: "{{ template_box_dir }}"
   when: vagrantfile.stat.exists is defined and vagrantfile.stat.exists

--- a/ansible/roles/box/prepare/tasks/main.yml
+++ b/ansible/roles/box/prepare/tasks/main.yml
@@ -24,6 +24,7 @@
     chdir: "{{ template_box_dir }}"
 
 - name: get IP from vagrant ssh-config
+  become: true
   shell: "vagrant ssh-config | grep HostName | sed 's/  HostName //'"
   args:
     chdir: "{{ template_box_dir }}"

--- a/ansible/vars/fedora/31.yml
+++ b/ansible/vars/fedora/31.yml
@@ -1,0 +1,3 @@
+---
+fedora_releasever: 31
+base_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-libvirt.box

--- a/ansible/vars/ipa_branches/ipa-4-6.yml
+++ b/ansible/vars/ipa_branches/ipa-4-6.yml
@@ -1,3 +1,6 @@
 ---
 freeipa_version: 4-6
 with_python2: 1
+
+# COPR repo `@freeipa/freeipa-4-6` not necessary anymore
+repo_freeipa_copr_enabled: 0


### PR DESCRIPTION
- Fix tasks failing with recent Fedora hosts
  - These changes are backwards compatible, but since Fedora 30 those changes
are required to continue to build images.
- Add Fedora 31 variables