### PR TITLE
Setup certificate authority on Windows Server

### DIFF
--- a/ansible/roles/windows/ad-root/tasks/certificate-authority.yaml
+++ b/ansible/roles/windows/ad-root/tasks/certificate-authority.yaml
@@ -1,0 +1,9 @@
+- name: Install Certification Authority feature
+  win_feature:
+    name: Adcs-Cert-Authority
+    include_management_tools: yes
+
+- name: setup Certification Authority
+  win_shell: Install-AdcsCertificationAuthority -CAType EnterpriseRootCA -Force
+  args:
+    creates: C:\Windows\System32\CertSrv\CertEnroll

--- a/ansible/roles/windows/ad-root/tasks/main.yml
+++ b/ansible/roles/windows/ad-root/tasks/main.yml
@@ -11,3 +11,5 @@
 - name: Restart
   win_reboot:
     test_command: 'dsquery user -name Administrator'
+
+- import_tasks: certificate-authority.yaml


### PR DESCRIPTION
Certificate Authority feature is required by test test_winsyncmigrate.py