### PR TITLE
Add freeipa-pr-ci2 to the whitelist

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -15,6 +15,7 @@
 - flo-renaud
 - frasertweedale
 - freeipa-pr-ci
+- freeipa-pr-ci2
 - frozencemetery
 - germanparente
 - gkaihorodova


### PR DESCRIPTION
This account is used to trigger some tests against its fork.

Signed-off-by: Armando Neto <abiagion@redhat.com>