### PR TITLE
Update prci-automation playbooks to support Fedora 30

### DIFF
--- a/ansible/roles/automation/setup/tasks/setup.yml
+++ b/ansible/roles/automation/setup/tasks/setup.yml
@@ -3,11 +3,13 @@
   dnf:
     state: present
     name:
-      - python3-github3py
+      # FIXME: Temporarily installing scratch build, revert it to `python3-github3py` when new version is released
+      - https://kojipkgs.fedoraproject.org/work/tasks/1082/39451082/python3-github3py-1.3.0-1.fc30.noarch.rpm
       - PyYAML
       - git
       - crontabs
-      - python2-tqdm
+      - python3-pip
+      - python3-tqdm
       - ansible
       - vagrant
       - libvirt
@@ -17,13 +19,12 @@
 
 - name: install pip dependencies
   pip:
-    name: "{{ item }}"
     executable: pip3
-  with_items:
-    - CacheControl
-    - requests
-    - gitpython
-    - ryd
+    name:
+      - CacheControl
+      - requests
+      - gitpython
+      - ryd
 
 - name: create base directory
   file:

--- a/github/open_close_pr.py
+++ b/github/open_close_pr.py
@@ -36,7 +36,7 @@ def load_yaml(yml_path):
     yaml = ruamel.yaml.YAML()
     try:
         with open(yml_path, 'r+') as yml_file:
-            return yaml.safe_load(yml_file)
+            return yaml.load(yml_file)
     except IOError as exc:
         raise argparse.ArgumentTypeError(
             'Failed to open {}: {}'.format(yml_path, exc))


### PR DESCRIPTION
Changes:
- Revert mistaken change
  - Change made by 1b9671e.
  - Method call replaced by mistake, this script is using a different
YAML library.
- Update prci-automation playbooks to support Fedora 30
  - Follow-up of 56479ec.
  - This includes a temporary fix for out-dated package `python3-github3py`.