### PR TITLE
Remove PyYAML from packages to be installed

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -47,7 +47,6 @@
   dnf:
     state: latest
     name:
-      - PyYAML  # ipa-vagrant-ci dependency
       - vim
       - NetworkManager
       - xorg-x11-server-Xvfb


### PR DESCRIPTION
This package is an alias to `python3-PyYAML` or `python3-pyyaml`
packages depending on Fedora release.

This alias is not valid in rawhide and the packages are already
installed by other jobs:

- https://github.com/freeipa/freeipa-pr-ci/blob/master/ansible/roles/machine/setup/tasks/install_packages.yml#L62
- https://github.com/freeipa/freeipa-pr-ci/blob/master/ansible/roles/machine/setup/tasks/install_packages.yml#L72

This was necessary to build new rawhide template:
https://app.vagrantup.com/freeipa/boxes/ci-master-frawhide/versions/0.0.10

Signed-off-by: Armando Neto <abiagion@redhat.com>