### PR TITLE
Replace nfs with sshfs as vagrant's synced folder mechanism

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -8,6 +8,12 @@
       set_fact:
         dns_forwarder: "{{ dns_server.stdout }}"
 
+    # https://github.com/ansible/ansible/issues/56243
+    - name: ensure file already exists at template dest to work around 'invalid selinux context' issue
+      file:
+        path: "/vagrant/ipa-test-config.yaml"
+        state: touch
+
     - name: create test config file
       template:
         src: ipa-test-config.yaml

--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -12,8 +12,7 @@ Vagrant.configure(2) do |config|
 
     config.ssh.username = "root"
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"
@@ -58,7 +57,8 @@ Vagrant.configure(2) do |config|
     config.vm.define "ad-root" do |ad_root|
         ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
-        ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
+        ad_root.vm.hostname = "ad-root"
+        ad_root.vm.synced_folder ".", "/vagrant", type: "sshfs", disabled: true
 
         ad_root.vm.provider "libvirt" do |domain, override|
             domain.cpus = 2

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -12,8 +12,7 @@ Vagrant.configure(2) do |config|
 
     config.ssh.username = "root"
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"
@@ -58,7 +57,8 @@ Vagrant.configure(2) do |config|
     config.vm.define "ad-root" do |ad_root|
         ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
-        ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
+        ad_root.vm.hostname = "ad-root"
+        ad_root.vm.synced_folder ".", "/vagrant", type: "sshfs", disabled: true
 
         ad_root.vm.provider "libvirt" do |domain, override|
             domain.cpus = 2

--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_3client
+++ b/templates/vagrantfiles/Vagrantfile.master_3client
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -7,8 +7,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
-        type: "nfs",
-        nfs_udp: false
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"


### PR DESCRIPTION
__Changes__:
- Replace nfs with sshfs as vagrant's synced folder mechanism
  - `vagrant-sshfs` plugin is already installed on the runners, this change
only replaces the mechanism defined in the vagrant files, disabling the
cache to make sure all files are synced, performance is not an issue in
this case.

- Touch ipa-test-config.yaml to work around ansible's selinux issue
  - The issue affects nfs and sshfs (fuse) file systems, making sure the file
exists fixes the problem.
  - This workaround is required only here because that is the only file under
`/vagrant/` that is generated by `template` module.


__Notes__: 
- I'm not removing NFS from source code at this moment to be easier to roll-back in case of some unexpected behaviour.

- SELinux workaround was tested using Fedora 31 with SELinux is permissive mode, pytest output: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/112adb38-2e5f-11ea-acf0-5254002d2921/report.html

- sshfs as synced folder mechanism test runs: https://github.com/netoarmando/freeipa/pull/37