### PR TITLE
Fix koji rpm url

### DIFF
--- a/ansible/roles/automation/setup/tasks/setup.yml
+++ b/ansible/roles/automation/setup/tasks/setup.yml
@@ -4,7 +4,7 @@
     state: present
     name:
       # FIXME: Temporarily installing scratch build, revert it to `python3-github3py` when new version is released
-      - https://kojipkgs.fedoraproject.org/work/tasks/1082/39451082/python3-github3py-1.3.0-1.fc30.noarch.rpm
+      - https://kojipkgs.fedoraproject.org/packages/python-github3py/1.3.0/1.fc30/noarch/python3-github3py-1.3.0-1.fc30.noarch.rpm
       - PyYAML
       - git
       - crontabs


### PR DESCRIPTION
Replacing scratch build with a proper rpm from Koji.

Previous rpm was deleted, so that url was returning 404 (not found).

Signed-off-by: Armando Neto <abiagion@redhat.com>