### PR TITLE
Revert NFS/SSHFS change for Fedora 27 guests

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -61,7 +61,6 @@ Vagrant.configure(2) do |config|
     config.vm.define "ad-root" do |ad_root|
         ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
-        ad_root.vm.hostname = "ad-root"
         {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
         ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
         {% else %}

--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -12,7 +12,11 @@ Vagrant.configure(2) do |config|
 
     config.ssh.username = "root"
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"
@@ -58,7 +62,11 @@ Vagrant.configure(2) do |config|
         ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
         ad_root.vm.hostname = "ad-root"
+        {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
+        {% else %}
         ad_root.vm.synced_folder ".", "/vagrant", type: "sshfs", disabled: true
+        {% endif %}
 
         ad_root.vm.provider "libvirt" do |domain, override|
             domain.cpus = 2

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -61,7 +61,6 @@ Vagrant.configure(2) do |config|
     config.vm.define "ad-root" do |ad_root|
         ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
-        ad_root.vm.hostname = "ad-root"
         {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
         ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
         {% else %}

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -12,7 +12,11 @@ Vagrant.configure(2) do |config|
 
     config.ssh.username = "root"
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"
@@ -58,7 +62,11 @@ Vagrant.configure(2) do |config|
         ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
         ad_root.vm.hostname = "ad-root"
+        {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
+        {% else %}
         ad_root.vm.synced_folder ".", "/vagrant", type: "sshfs", disabled: true
+        {% endif %}
 
         ad_root.vm.provider "libvirt" do |domain, override|
             domain.cpus = 2

--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_3client
+++ b/templates/vagrantfiles/Vagrantfile.master_3client
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -7,7 +7,11 @@ Vagrant.configure(2) do |config|
     config.ssh.username = "root"
 
     config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
         type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
 
     config.vm.box = "{{ vagrant_template_name }}"
     config.vm.box_version = "{{ vagrant_template_version }}"


### PR DESCRIPTION
Changes made in 11149e5de4140d1b62bd63dd6c23a5b1a9e7c917 didn't work with Fedora 27 guests, for now this is a quick and dirty fix while we still support Fedora 27 (AKA `ci-ipa-4-6-f27` template).

Signed-off-by: Armando Neto <abiagion@redhat.com>

This addresses this https://github.com/freeipa/freeipa/pull/4120#issuecomment-573429906.