### PR TITLE
Fix `vagrant destroy` command.

### DIFF
--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -92,7 +92,7 @@ class VagrantCleanup(VagrantTask):
     def _run(self):
         logging.info("Destroying vagrant machines.")
         self.execute_subtask(
-            PopenTask(["vagrant", "destroy"], raise_on_err=False))
+            PopenTask(["vagrant", "destroy", "--force"], raise_on_err=False))
 
 class VagrantBoxDownload(VagrantTask):
     def __init__(self, box_name, box_version, link_image=True, **kwargs):


### PR DESCRIPTION
New version of vagrant asks user for confirmation when destroying domains.
Since we run `vagrant destroy` in non-interactive way, it complains and
exits with status code 1, leaving the domains running.
Fixing it by adding "--force" option.

The problem can be seen in runner.log of any job:
```
2020-01-16 00:51:35,665     INFO  Executing: VagrantCleanup
2020-01-16 00:51:35,666     INFO  Destroying vagrant machines.
2020-01-16 00:51:35,667     INFO  Executing: Process "vagrant destroy"
2020-01-16 00:51:37,480    DEBUG  Vagrant is attempting to interface with the UI in a way that requires
2020-01-16 00:51:37,480    DEBUG  a TTY. Most actions in Vagrant that require a TTY have configuration
2020-01-16 00:51:37,481    DEBUG  switches to disable this requirement. Please do that or run Vagrant
2020-01-16 00:51:37,481    DEBUG  with TTY.
2020-01-16 00:51:37,494  WARNING  Process "vagrant destroy" exited with error code 1
Traceback (most recent call last):
  File "/root/freeipa-pr-ci/tasks/common.py", line 124, in __call__
    super(FallibleTask, self).__call__()
  File "/root/freeipa-pr-ci/tasks/common.py", line 111, in __call__
    raise self.exc
  File "/root/freeipa-pr-ci/tasks/common.py", line 94, in __target
    self._run()
  File "/root/freeipa-pr-ci/tasks/common.py", line 161, in _run
    raise PopenException(self)
tasks.common.PopenException: Process "vagrant destroy" exited with error code 1
```

This issue does not affect normal operation since there is backup for cleaning up running domains: https://github.com/freeipa/freeipa-pr-ci/blob/fa5b1087fb2e80aa19c7ec50aa8c9ce687c3b2e5/github/prci.py#L311