### PR TITLE
Host vagrant catalog on prci-automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ jobs directories.
 This feature can be disabled setting `activate_autocleaner: false` in the
 particular playbook.
 
+#### Vagrant box hosting
+
+PR-CI is capable of proxying and hosting boxes from Vagrant, speeding up the
+provisioning phase if the box is not in place.
+
+For that you need to provision runners answering the question:
+"Custom vagrant catalog host (ip address) (Press enter to ignore)"
+
+If you provide the IP address of `prci-automation` then all runners will set
+that to `VAGRANT_SERVER_URL` environment variable and Vagrant will fetch boxesq
+from that address.
+
+##### Cache vagrant boxes
+
+On `prci-automation` you can run the following script to download the boxes,
+making them available locally:
+
+```
+$ scripts/cache-vagrant-box.py {username} {boxname} {version}
+```
+
+E.g:
+
+```
+scripts/cache-vagrant-box.py freeipa ci-master-f31 0.0.1
+```
+
 ## User Guide
 
 ### Re-running tasks

--- a/ansible/prepare_devel_test_runners.yml
+++ b/ansible/prepare_devel_test_runners.yml
@@ -15,6 +15,11 @@
     - name: pr_ci_repo_branch
       prompt: Branch of PR CI repo to deploy
       private: false
+      # Set the IP address to prci-automation hosting vagrant boxes
+    - name: custom_vagrant_catalog
+      prompt: Custom vagrant catalog host (ip address) (Press enter to ignore)
+      default: false
+      private: false
   gather_facts: false
   pre_tasks:
     - name: check we're not deploying against FreeIPA repo

--- a/ansible/prepare_openclose_pr_tool.yml
+++ b/ansible/prepare_openclose_pr_tool.yml
@@ -49,6 +49,7 @@
       when: github_token != "" and  repo_owner != 'freeipa'
     - role: automation/nightly_pr
       when: github_token != "" and  repo_owner != 'freeipa'
+    - role: automation/box_hosting  # host vagrant catalog
     # TODO: Enable automated template generation
     # - role: automation/template_pr
     #   when: github_token != "" and  repo_owner != 'freeipa'

--- a/ansible/prepare_test_runners.yml
+++ b/ansible/prepare_test_runners.yml
@@ -6,6 +6,11 @@
     - name: github_token
       prompt: API token for GitHub
       private: false
+      # Set the IP address to prci-automation hosting vagrant boxes
+    - name: custom_vagrant_catalog
+      prompt: Custom vagrant catalog host (ip address) (Press enter to ignore)
+      default: false
+      private: false
   gather_facts: false
   pre_tasks:
     - name: install Python 3 deps for ansible modules

--- a/ansible/roles/automation/box_hosting/files/404.json
+++ b/ansible/roles/automation/box_hosting/files/404.json
@@ -1,0 +1,6 @@
+{
+  "errors": [
+    "Not found local"
+  ],
+  "success": false
+}

--- a/ansible/roles/automation/box_hosting/files/app.py
+++ b/ansible/roles/automation/box_hosting/files/app.py
@@ -1,0 +1,63 @@
+import json
+import logging
+import os
+import pathlib
+
+import requests
+from flask import Flask, make_response, request
+from requests.exceptions import RequestException
+
+VAGRANT_URL = 'https://app.vagrantup.com/{user_name}/boxes/{box_name}.json'
+CATALOG_PATH = '/usr/share/nginx/html/catalog'
+
+logging.basicConfig(level=logging.INFO)
+
+app = Flask(__name__)
+
+
+def replace_box_domain(catalog, domain):
+    '''Replace provider urls to point to `domain`.'''
+    for ver_key, version in enumerate(catalog['versions']):
+        for pro_key, provider in enumerate(version['providers']):
+            new_url = provider['url'].replace(
+                'https://vagrantcloud.com/', domain
+            )
+            catalog['versions'][ver_key]['providers'][pro_key]['url'] = new_url
+    return catalog
+
+
+def save_catalog(catalog_data, user_name, box_name):
+    '''Save catalog file to `CATALOG_PATH/{user_name}/{box_name}.json`.'''
+    app.logger.info(f'Saving catalog for {user_name}/{box_name}.')
+
+    folder_path = os.path.join(CATALOG_PATH, user_name)
+    pathlib.Path(folder_path).mkdir(parents=True, exist_ok=True)
+
+    catalog_path = os.path.join(folder_path, box_name + '.json')
+
+    with open(catalog_path, 'w', encoding='utf-8') as catalog_file:
+        json.dump(catalog_data, catalog_file)
+
+
+@app.route('/<user_name>/<box_name>')
+def get_box(user_name, box_name):
+    '''Fetch catalog from `VAGRANT_URL`, store and return original data.'''
+    app.logger.info(f'Fetching catalog for {user_name}/{box_name}.')
+    try:
+        response = requests.get(
+            VAGRANT_URL.format(user_name=user_name, box_name=box_name)
+        )
+        catalog = response.json()
+
+        if response.status_code == requests.codes['ok']:
+            domain = request.host_url
+            catalog = replace_box_domain(catalog, domain)
+
+            save_catalog(
+                user_name=user_name, box_name=box_name, catalog_data=catalog,
+            )
+
+        return make_response(catalog, response.status_code)
+    except RequestException:
+        app.logger.exception(f'Error while fetching {user_name}/{box_name}.')
+        return make_response(catalog, requests.codes['server_error'])

--- a/ansible/roles/automation/box_hosting/files/gunicorn.service
+++ b/ansible/roles/automation/box_hosting/files/gunicorn.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=gunicorn daemon
+Requires=gunicorn.socket
+After=network.target
+
+[Service]
+User=nginx
+Group=nginx
+WorkingDirectory=/usr/share/nginx/
+ExecStart=/usr/bin/gunicorn-3 -w 4 app:app
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop = /bin/kill -s TERM $MAINPID
+#KillMode=mixed
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/automation/box_hosting/files/gunicorn.socket
+++ b/ansible/roles/automation/box_hosting/files/gunicorn.socket
@@ -1,0 +1,14 @@
+[Unit]
+Description=gunicorn socket
+
+[Socket]
+ListenStream=/run/gunicorn.sock
+# Our service won't need permissions for the socket, since it
+# inherits the file descriptor by socket activation
+# only the nginx daemon will need access to the socket
+User=nginx
+# Optionally restrict the socket permissions even more.
+# Mode=600
+
+[Install]
+WantedBy=sockets.target

--- a/ansible/roles/automation/box_hosting/files/nginx.conf
+++ b/ansible/roles/automation/box_hosting/files/nginx.conf
@@ -1,0 +1,67 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80 default_server;
+        listen       [::]:80 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location ~ \.box {
+            try_files $uri @vagrant;
+        }
+
+        location / {
+            rewrite  ^/(.*)/(.*)$ /$1/$2.json break;
+            try_files /catalog/$uri @fallback;
+        }
+
+        location @vagrant {
+            return 302 https://vagrantcloud.com$request_uri;
+
+        }
+        location @fallback {
+            rewrite ^ /$request_uri break;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_pass http://unix:/run/gunicorn.sock;
+        }
+
+        error_page 404 /404.json;
+            location = /404.json {
+        }
+
+    }
+
+}

--- a/ansible/roles/automation/box_hosting/tasks/main.yml
+++ b/ansible/roles/automation/box_hosting/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+# These tasks install a web server (nginx) to host vagrant catalog and boxes.
+#
+# To install boxes from this host just run the below command on your runner:
+# $ export VAGRANT_SERVER_URL='http://URL_TO_THIS_PRCI_AUTOMATION_HOST'
+#
+# Request to http://prci-automation/freeipa/ci-master-f30 will return the catalog
+# you can use any combination of username/boxname.
+#
+# Requests to boxes not available (not downloaded) will be redirected to 
+# vagrantup.com.
+#
+# To download a box to be hosted by prci-automation you need to run:
+# `scripts/cache-vagrant-box.py {username} {boxname} {version}`
+#
+# E.g: `scripts/cache-vagrant-box.py freeipa ci-master-f31 0.0.1`
+- name: install latest (pip) Flask Web framework
+  pip:
+    executable: pip3
+    name: Flask
+
+- name: install nginx and gunicorn
+  dnf:
+    state: present
+    name:
+      - nginx
+      - python3-gunicorn
+
+- name: copy nginx settings
+  copy:
+    src: nginx.conf
+    dest: /etc/nginx/nginx.conf
+
+- name: copy flask application
+  copy:
+    src: app.py
+    dest: /usr/share/nginx/app.py
+
+- name: copy 404.json
+  copy:
+    src: 404.json
+    dest: /usr/share/nginx/html/404.json
+
+- name: create systemd unit for gunicorn
+  copy:
+    src: gunicorn.service
+    dest: /etc/systemd/system/gunicorn.service
+
+- name: create catalog directory
+  file:
+    path: /usr/share/nginx/html/catalog
+    state: directory
+    owner: nginx
+    group: nginx
+    mode: 0700
+
+- name: create socket file for gunicorn
+  copy:
+    src: gunicorn.socket
+    dest: /etc/systemd/system/gunicorn.socket
+
+- name: systemd daemon reload
+  shell: systemctl daemon-reload
+
+- name: enable gunicorn
+  service:
+    enabled: true
+    state: started
+    name: gunicorn.socket
+
+- name: reload nginx service
+  systemd:
+    state: reloaded
+    name: nginx

--- a/ansible/roles/runner/tasks/custom_vagrant_catalog.yml
+++ b/ansible/roles/runner/tasks/custom_vagrant_catalog.yml
@@ -1,0 +1,24 @@
+---
+# Configure host to fetch boxes from custom catalog (prci-automation)
+- name: Add prci-automation entry to /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    regexp: "prci-automation$"
+    line: "{{ custom_vagrant_catalog }} prci-automation"
+
+- name: Set "VAGRANT_SERVER_URL" Environment variable
+  ini_file:
+    path: /etc/systemd/system/prci.service
+    section: Service
+    option: Environment
+    value: "VAGRANT_SERVER_URL='http://prci-automation'"
+    mode: 0700
+
+- name: systemd daemon reload
+  shell: systemctl daemon-reload
+
+- name: restart prci
+  service:
+    name: prci
+    enabled: true
+    state: restarted

--- a/ansible/roles/runner/tasks/deploy_pr_ci.yml
+++ b/ansible/roles/runner/tasks/deploy_pr_ci.yml
@@ -25,6 +25,11 @@
     src: config.yml
     dest: /root/.config/freeipa-pr-ci/config.yml
 
+- name: ensure vagrant_boxes_stats.yml exists
+  file:
+    path: /root/.config/freeipa-pr-ci/vagrant_boxes_stats.yml
+    state: touch
+
 - name: create systemd unit for prci
   copy:
     src: prci.service

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -12,6 +12,8 @@
 - include: deploy_pr_ci.yml
 - include: autocleaner.yml
   when: activate_autocleaner
+- include: custom_vagrant_catalog.yml
+  when: custom_vagrant_catalog is defined and custom_vagrant_catalog != 'False'
 
 - include_role:
     name: utils

--- a/ansible/roles/runner/templates/config.yml
+++ b/ansible/roles/runner/templates/config.yml
@@ -5,6 +5,7 @@ credentials:
     token: {{ github_token }}
 tasks_file: .freeipa-pr-ci.yaml
 whitelist_file: /root/freeipa-pr-ci/whitelist.yml
+box_stats_file: /root/.config/freeipa-pr-ci/vagrant_boxes_stats.yml
 no_task_backoff_time: {{ no_task_backoff_time }}
 logging:
     version: 1

--- a/github/prci.py
+++ b/github/prci.py
@@ -14,6 +14,7 @@ import github3
 import yaml
 from github3.exceptions import NotFoundError
 
+import tasks
 from internals.entities import (
     ExitHandler, JobDispatcher, PullRequest, Status, Task, World,
     sentry_report_exception, JobYAMLError
@@ -236,6 +237,7 @@ def main():
     runner_id = args.ID
     config = args.config
 
+    tasks.BOX_STATS_FILE = config["box_stats_file"]
     credentials = config["credentials"]
     repo = config["repository"]
     tasks_path = config["tasks_file"]

--- a/scripts/cache-vagrant-box.py
+++ b/scripts/cache-vagrant-box.py
@@ -1,0 +1,126 @@
+#!/bin/env python3
+import argparse
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import requests
+from requests.exceptions import RequestException
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+VAGRANT_URL = 'https://app.vagrantup.com/{user_name}/boxes/{box_name}.json'
+CATALOG_PATH = '/usr/share/nginx/html'
+
+BOX_PATH_PATTERN = (
+    '{user_name}/boxes/{box_name}/versions/{box_version}/'
+    'providers/{provider_name}.box'
+)
+
+
+def download_box(user_name, box_name, box_version):
+    '''Download box to CATALOG_PATH, following the same structure as Vagrant.
+    '''
+    try:
+        response = requests.get(
+            VAGRANT_URL.format(user_name=user_name, box_name=box_name)
+        )
+        response.raise_for_status()
+    except RequestException:
+        logger.error(
+            f'Could not fetch data for {user_name}/{box_name} ({box_version}).'
+        )
+        return 1
+    data = response.json()
+
+    try:
+        versions = [v for v in data['versions'] if v['version'] == box_version]
+        version = versions[0]
+        if version['status'] != 'active':
+            logger.error(f'Version "{box_version}" not active.')
+            return
+    except IndexError:
+        logger.error(f'Version "{box_version}" not available.')
+        return 1
+
+    try:
+        providers = [p for p in version['providers'] if p['name'] == 'libvirt']
+        provider = providers[0]
+    except IndexError:
+        logger.error(f'Provider "libvirt" not available.')
+        return 1
+
+    temp_box_path = os.path.join(
+        '/tmp/temp_boxes',
+        BOX_PATH_PATTERN.format(
+            user_name=user_name,
+            box_name=box_name,
+            box_version=box_version,
+            provider_name='libvirt',
+        ),
+    )
+    final_box_path = os.path.join(
+        CATALOG_PATH,
+        BOX_PATH_PATTERN.format(
+            user_name=user_name,
+            box_name=box_name,
+            box_version=box_version,
+            provider_name='libvirt',
+        ),
+    )
+
+    logger.info(f'Downloading box to "{temp_box_path}".')
+
+    subprocess.run([
+        'curl',
+        '-q',
+        '--fail',
+        '--location',
+        '--create-dirs',
+        # '--silent',
+        '--continue-at',
+        '-',
+        '--output',
+        temp_box_path,
+        provider['url'],
+    ])
+
+    logger.info(f'Moving box to "{final_box_path}".')
+
+    pathlib.Path(os.path.dirname(final_box_path)).mkdir(
+        parents=True, exist_ok=True
+    )
+    shutil.move(temp_box_path, final_box_path)
+
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='''
+    Download a vagrant box to be stored and served by this machine.
+    ''')
+
+    parser.add_argument('user_name', help='User name of box owner.')
+    parser.add_argument('box_name', help='Box name.')
+    parser.add_argument('box_version', help='Box version.')
+
+    parser.add_argument('--catalog-path', dest='catalog_path', type=str,
+                        help=f'Where the box will be saved ({CATALOG_PATH}).',
+                        default=CATALOG_PATH)
+
+    args = parser.parse_args()
+
+    # override constant
+    CATALOG_PATH = args.catalog_path
+
+    # Call function
+    return_code = download_box(
+        user_name=args.user_name,
+        box_name=args.box_name,
+        box_version=args.box_version,
+    )
+    sys.exit(return_code)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,2 +1,5 @@
 from .common import logging_init_stream_handler, TimeoutException
 from .tasks import Build, RunPytest, RunWebuiTests, RunPytest2, RunPytest3
+
+# Singleton constant used to store stats file path
+BOX_STATS_FILE = None

--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -1,12 +1,16 @@
 import logging
 import os
-import signal
+import re
+import subprocess
 import time
+from datetime import datetime
+
+import yaml
+
+import tasks
 
 from . import constants
-from .common import (
-    PopenTask, PopenException, FallibleTask, TaskException
-)
+from .common import FallibleTask, PopenTask, TaskException
 
 
 def with_vagrant(func):
@@ -94,6 +98,7 @@ class VagrantCleanup(VagrantTask):
         self.execute_subtask(
             PopenTask(["vagrant", "destroy"], raise_on_err=False))
 
+
 class VagrantBoxDownload(VagrantTask):
     def __init__(self, box_name, box_version, link_image=True, **kwargs):
         """
@@ -105,7 +110,13 @@ class VagrantBoxDownload(VagrantTask):
         self.link_image = True
 
     def _run(self):
+        self.box.update_latest_use()
+
         if not self.box.exists():
+            # If necessary delete oldest box to save space before downloading a
+            # new one
+            VagrantBox.delete_oldest_box()
+
             try:
                 self.execute_subtask(
                     PopenTask([
@@ -162,8 +173,73 @@ class VagrantBox(object):
             libvirt_name=self.libvirt_name,
             version=self.version)
 
+    @property
+    def last_time_used(self):
+        box_key = '{name}_{version}_{provider}'.format(
+            name=self.name, version=self.version, provider=self.provider)
+        with open(tasks.BOX_STATS_FILE, 'r') as stats_file:
+            stats = yaml.safe_load(stats_file)
+            if not stats:
+                stats = {}
+
+        return stats.get(box_key, None)
+
+    @staticmethod
+    def delete_oldest_box():
+        all_boxes = sorted(
+            VagrantBox.installed_boxes(), key=lambda x: x.last_time_used)
+
+        # Do not delete Windows boxes
+        linux_boxes = [x for x in all_boxes if 'windows' not in x.name]
+        if len(linux_boxes) > 4:
+            linux_boxes[0].delete_box()
+
+    @staticmethod
+    def installed_boxes():
+        output = subprocess.check_output(
+            ['vagrant', 'box', 'list'], timeout=2000)
+
+        if 'There are no installed boxes!' in output.decode():
+            return []
+
+        all_boxes = []
+        for box_data in output.decode().strip().split('\n'):
+            matches = re.search(
+                r'(?P<name>[\/\w-]+)\s+\((?P<provider>[\w-]+)\,\s(?P<version>[\w.]+)\)',  # noqa
+                output.decode(),
+            )
+            box = VagrantBox(
+                name=matches.group('name'),
+                version=matches.group('version'),
+                provider=matches.group('provider'),
+            )
+            all_boxes.append(box)
+
+        return all_boxes
+
+    def update_latest_use(self):
+        box_key = '{name}_{version}_{provider}'.format(
+            name=self.name, version=self.version, provider=self.provider)
+        with open(tasks.BOX_STATS_FILE, 'r+') as stats_file:
+            stats = yaml.safe_load(stats_file)
+            if not stats:
+                stats = {}
+
+        stats[box_key] = datetime.now()
+        with open(tasks.BOX_STATS_FILE, 'w+') as stats_file:
+            yaml.dump(stats, stats_file)
+
     def exists(self):
         return os.path.exists(self.vagrant_path)
 
     def libvirt_exists(self):
         return os.path.exists(self.libvirt_path)
+
+    def delete_box(self):
+        subprocess.run([
+            'vagrant', 'box', 'remove', self.name, '--provider', self.provider,
+            '--box-version', self.version
+        ], timeout=2000)
+
+        subprocess.run(
+            ['virsh', 'vol-delete', self.libvirt_path], timeout=2000)


### PR DESCRIPTION
These tasks install a web server (nginx) to host vagrant catalog and boxes.

To install boxes from this host just run the below command on your runner:
```
$ export VAGRANT_SERVER_URL='http://URL_TO_THIS_PRCI_AUTOMATION_HOST'
```

Request to http://prci-automation/freeipa/ci-master-f30 will return the catalog
you can use any combination of username/boxname.

Requests to boxes not available (not downloaded) will be redirected to
vagrantup.com.

To download a box to be hosted by prci-automation you need to run:
```
$scripts/cache-vagrant-box.py {username} {boxname} {version}`
```

E.g: `scripts/cache-vagrant-box.py freeipa ci-master-f31 0.0.1`

Signed-off-by: Armando Neto <abiagion@redhat.com>

![Peek 2020-01-22 01-20](https://user-images.githubusercontent.com/217367/72865139-7a7d4a80-3cb5-11ea-8748-e10a6c379d77.gif)
