### PR TITLE
Enable SELinux in permissive mode

### DIFF
--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-selinux_mode: disabled
+selinux_mode: permissive
 copr_repo: "@freeipa/freeipa-master"
 python_packages_to_install:
   - pytest-html

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -113,11 +113,6 @@
     executable: pip3
     name: "{{ python_packages_to_install }}"
 
-- name: install py2 pip dependencies
-  pip:
-    executable: pip
-    name: "{{ python_packages_to_install }}"
-
 - name: download geckodriver
   shell: |
         VERSION=$(curl https://github.com/mozilla/geckodriver/releases/latest 2>/dev/null | \

--- a/ansible/vars/flows/389ds.yml
+++ b/ansible/vars/flows/389ds.yml
@@ -1,7 +1,7 @@
 ---
 repo_389ds_testing_enabled: 1
 repo_fedora_enabled: 1
-repo_freeipa_copr_enabled: 1
+repo_freeipa_copr_enabled: 0
 repo_pki_master_enabled: 0
 repo_pki_testing_enabled: 0
 repo_updates_enabled: 1

--- a/ansible/vars/flows/ci.yml
+++ b/ansible/vars/flows/ci.yml
@@ -1,7 +1,7 @@
 ---
 repo_389ds_testing_enabled: 0
 repo_fedora_enabled: 1
-repo_freeipa_copr_enabled: 1
+repo_freeipa_copr_enabled: 0
 repo_pki_master_enabled: 0
 repo_pki_testing_enabled: 0
 repo_updates_enabled: 1

--- a/ansible/vars/flows/pki.yml
+++ b/ansible/vars/flows/pki.yml
@@ -1,7 +1,7 @@
 ---
 repo_389ds_testing_enabled: 0
 repo_fedora_enabled: 1
-repo_freeipa_copr_enabled: 1
+repo_freeipa_copr_enabled: 0
 repo_pki_master_enabled: 1
 repo_pki_testing_enabled: 0
 repo_updates_enabled: 1

--- a/ansible/vars/flows/testing.yml
+++ b/ansible/vars/flows/testing.yml
@@ -1,7 +1,7 @@
 ---
 repo_389ds_testing_enabled: 0
 repo_fedora_enabled: 1
-repo_freeipa_copr_enabled: 1
+repo_freeipa_copr_enabled: 0
 repo_pki_master_enabled: 0
 repo_pki_testing_enabled: 0
 repo_updates_enabled: 1

--- a/ansible/vars/ipa_branches/ipa-4-6.yml
+++ b/ansible/vars/ipa_branches/ipa-4-6.yml
@@ -1,6 +1,3 @@
 ---
 freeipa_version: 4-6
 with_python2: 1
-
-# COPR repo `@freeipa/freeipa-4-6` not necessary anymore
-repo_freeipa_copr_enabled: 0

--- a/ansible/vars/ipa_branches/master.yml
+++ b/ansible/vars/ipa_branches/master.yml
@@ -1,2 +1,5 @@
 ---
 freeipa_version: master
+
+# Only master 
+repo_freeipa_copr_enabled: 1


### PR DESCRIPTION
This reverts commit f181d0b, where SELinux had to be disable after an issue with Ansible, a workaround to that issue was added in 3773203.

Enable COPR repo only for master branch templates. Recent changes to COPR made [@freeipa/freeipa-master](https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/packages/) the only repo to host freeipa's dependencies. Other repos include freeipa packages.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/266