### PR TITLE
Fix date comparison when boxes where already installed in the system

### DIFF
--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -3,7 +3,7 @@ import os
 import re
 import subprocess
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import yaml
 
@@ -186,8 +186,15 @@ class VagrantBox(object):
 
     @staticmethod
     def delete_oldest_box():
+        def clean_last_time_used(box):
+            '''Return "yesterday" for boxes previously installed in the system.
+            '''
+            if box.last_time_used:
+                return box.last_time_used
+            return datetime.now() - timedelta(days=1)
+
         all_boxes = sorted(
-            VagrantBox.installed_boxes(), key=lambda x: x.last_time_used)
+            VagrantBox.installed_boxes(), key=clean_last_time_used)
 
         # Do not delete Windows boxes
         linux_boxes = [x for x in all_boxes if 'windows' not in x.name]


### PR DESCRIPTION
Follow-up for 70e0ab24c1c8d8d435831c1324821ec4561cef97.

Signed-off-by: Armando Neto <abiagion@redhat.com>

This was tested in parallel infra: https://github.com/freeipa-pr-ci2/freeipa/pull/130
