### PR TITLE
vagrant catalog provisioning fixes and improvements 

### DIFF
--- a/ansible/roles/automation/box_hosting/tasks/main.yml
+++ b/ansible/roles/automation/box_hosting/tasks/main.yml
@@ -26,6 +26,11 @@
       - nginx
       - python3-gunicorn
 
+- name: set selinux to permissive
+  selinux:
+    policy: targeted
+    state: permissive
+
 - name: copy nginx settings
   copy:
     src: nginx.conf
@@ -66,7 +71,7 @@
   service:
     enabled: true
     state: started
-    name: gunicorn.socket
+    name: gunicorn
 
 - name: reload nginx service
   systemd:

--- a/ansible/roles/runner/tasks/custom_vagrant_catalog.yml
+++ b/ansible/roles/runner/tasks/custom_vagrant_catalog.yml
@@ -1,18 +1,27 @@
 ---
 # Configure host to fetch boxes from custom catalog (prci-automation)
-- name: Add prci-automation entry to /etc/hosts
-  lineinfile:
-    path: /etc/hosts
-    regexp: "prci-automation$"
-    line: "{{ custom_vagrant_catalog }} prci-automation"
-
-- name: Set "VAGRANT_SERVER_URL" Environment variable
+- name: Reset "VAGRANT_SERVER_URL" Environment variable
   ini_file:
     path: /etc/systemd/system/prci.service
     section: Service
     option: Environment
-    value: "VAGRANT_SERVER_URL='http://prci-automation'"
-    mode: 0700
+    state: absent
+
+- block:
+    - name: Add prci-automation entry to /etc/hosts
+      lineinfile:
+        path: /etc/hosts
+        regexp: "prci-automation$"
+        line: "{{ custom_vagrant_catalog }} prci-automation"
+
+    - name: Set "VAGRANT_SERVER_URL" Environment variable
+      ini_file:
+        path: /etc/systemd/system/prci.service
+        section: Service
+        option: Environment
+        value: "VAGRANT_SERVER_URL='http://prci-automation'"
+        mode: 0700
+  when: custom_vagrant_catalog is defined and custom_vagrant_catalog != 'False'
 
 - name: systemd daemon reload
   shell: systemctl daemon-reload

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -13,7 +13,6 @@
 - include: autocleaner.yml
   when: activate_autocleaner
 - include: custom_vagrant_catalog.yml
-  when: custom_vagrant_catalog is defined and custom_vagrant_catalog != 'False'
 
 - include_role:
     name: utils


### PR DESCRIPTION
- Add missing vagrant catalog tasks
  - SELinux was blocking nginx to talk to gunicorn socket.
  - Gnunicorn service wasn't enabled nor started after `gunicon.socket` service was started.
- Reset environment variable to use Vagrant's default catalog
  - This can be used to easily rollback PR-CI to use Vagrant's catalog if `prci-automation` is not available.
