### PR TITLE
Return head commit from pull requests

### DIFF
--- a/github/internals/gql/queries.py
+++ b/github/internals/gql/queries.py
@@ -9,6 +9,7 @@ def make_pull_requests_query(owner: Text, repo: Text) -> Dict[Text, Text]:
       nodes {
         number
         baseRefName
+        headRefOid
         mergeable
         author {
           login
@@ -18,7 +19,7 @@ def make_pull_requests_query(owner: Text, repo: Text) -> Dict[Text, Text]:
             name
           }
         }
-        commits(last: 1) {
+        commits(last: 250) {
           nodes {
             commit {
               oid
@@ -52,7 +53,8 @@ def make_pull_request_query(
         "query": """{
   repository(owner: "%s", name: "%s") {
     pullRequest(number: %s) {
-      commits(last: 1) {
+      headRefOid
+      commits(last: 250) {
         nodes {
           commit {
             oid

--- a/github/internals/gql/util.py
+++ b/github/internals/gql/util.py
@@ -58,8 +58,10 @@ def get_pull_requests(repository: Dict) -> List[Dict]:
 
 
 def get_last_commit(pull_request: Dict) -> Dict:
-    """Extracts last pull request from a given pull request."""
-    return pull_request["commits"]["nodes"][0]["commit"]
+    """Extracts head commit from a given pull request."""
+    for commit in pull_request["commits"]["nodes"]:
+        if commit["commit"]["oid"] == pull_request["headRefOid"]:
+            return commit["commit"]
 
 
 def get_commit_sha(commit: Dict) -> Text:


### PR DESCRIPTION
Github sorts commits by their 'author date', not by their order in tree, thus last commit it's not always the head of a pull request.

This returns the commit matching its `oid` (hash) with pull request's `headRefOid` value.

Last 250 (maximum allowed) commits from a given pull request must be fetched to keep the number of API requests the same as it is.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/264

Pull request used for testing this: https://github.com/netoarmando/freeipa/pull/47

---
@frasertweedale I was writing the commit message for the solution we discussed, then I decided to take another look to github's doc and I've found the `headRefOid` property. :-D