### PR TITLE
Update nightly jobs to include new ipa-4-8 test

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -42,13 +42,21 @@ nightly_jobs:
     branch: "ipa-4-7"
     prci_config: "nightly_ipa-4-7.yaml"
 
-  - name: testing_ipa-4.8
+  - name: testing_ipa-4.8_latest
+    weekdays: "6"
+    hour: "8"
+    minute: "00"
+    flow: "ci"
+    branch: "ipa-4-8"
+    prci_config: "nightly_ipa-4-8_latest.yaml"
+
+  - name: testing_ipa-4.8_previous
     weekdays: "6"
     hour: "15"
     minute: "00"
     flow: "ci"
     branch: "ipa-4-8"
-    prci_config: "nightly_ipa-4-8.yaml"
+    prci_config: "nightly_ipa-4-8_previous.yaml"
 
   - name: testing_master_pki
     weekdays: "7"


### PR DESCRIPTION
After [this change](https://github.com/freeipa/freeipa/commit/c1660a4c023a28cdad40720fd91d7e57870b4808) in freeipa the scenarios changed to test `ipa-4-8` branch with latest and previous releases of Fedora. This commit updates prci-automation crontab to reflect that change.

Signed-off-by: Armando Neto <abiagion@redhat.com>