### PR TITLE
install tests dependencies specific to Fedora 27

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -49,6 +49,14 @@
     - samba-client
   when: testing_ad is defined
 
+- name: install Fedora 27 specific tests dependencies
+  dnf:
+    state: latest
+    name:
+      - ntpdate
+      - sssd-tools
+  when: ansible_distribution == 'Fedora' and ansible_distribution_version == '27'
+
 - name: create directory to save installed packages logs
   file:
     path: /vagrant/installed_packages/


### PR DESCRIPTION
The dependencies are required for testing ipa-4-6 branch
* ntpdate is required by AD trust related tests
* sssd-tools is required by new tests in sssd