### PR TITLE
Update nighlty runs crontab

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -34,14 +34,6 @@ nightly_jobs:
     branch: "ipa-4-6"
     prci_config: "nightly_ipa-4-6.yaml"
 
-  - name: testing_ipa-4.7
-    weekdays: "7"
-    hour: "10"
-    minute: "00"
-    flow: "ci"
-    branch: "ipa-4-7"
-    prci_config: "nightly_ipa-4-7.yaml"
-
   - name: testing_ipa-4.8_latest
     weekdays: "6"
     hour: "8"

--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -67,8 +67,8 @@ nightly_jobs:
     prci_config: "nightly_latest_389ds.yaml"
 
   - name: testing_master_testing
-    weekdays: "6"
-    hour: "10"
+    weekdays: "7"
+    hour: "2"
     minute: "00"
     flow: "testing"
     branch: "master"


### PR DESCRIPTION
* Disable ipa-4-7 nightly run 
    FreeIPA 4.7.5 is the last release in ipa-4-7, thus no more pull requests will target ipa-4-7 branch.
    More info:
    https://lists.fedorahosted.org/archives/list/freeipa-users@lists.fedorahosted.org/thread/FYUNCFWHY25OESUFDAOJWL6ELYQJ5FQ2/
    **Note**: This is already in production, cron was updated to not trigger `ipa-4-7` runs.

* Move test executing time to not clash with another
    `testing_master_testing` time was clashing with `testing_master_rawhide`.