### PR TITLE
Changes required to build Fedora 32+ templates

### DIFF
--- a/ansible/roles/box/package/tasks/main.yml
+++ b/ansible/roles/box/package/tasks/main.yml
@@ -48,3 +48,5 @@
       "{{ template_box_name }}" \
       "{{ template_box_dir }}/{{ template_box_name }}.box" \
       --bump-revision
+  tags:
+    - upload_box

--- a/ansible/roles/box/prepare/tasks/main.yml
+++ b/ansible/roles/box/prepare/tasks/main.yml
@@ -4,6 +4,8 @@
 
 - include: download_rawhide_box.yml
   when: fedora_version == 'rawhide'
+  tags:
+    - download_rawhide_box
 
 - name: create folder for image
   file:

--- a/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
@@ -7,6 +7,8 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '{{ fedora_releasever }}'
 config_opts['package_manager'] = 'dnf'
 
+{# tmpfs plugin disabled for Fedora 32 and Rawhide to workaround a build failure #}
+{% if fedora_releasever < 32 %}
 # Configure tmpfs to speed up mock
 config_opts['plugin_conf']['tmpfs_enable'] = True
 config_opts['plugin_conf']['tmpfs_opts'] = {}
@@ -14,6 +16,7 @@ config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb'] = 1024
 config_opts['plugin_conf']['tmpfs_opts']['max_fs_size'] = '4g'
 config_opts['plugin_conf']['tmpfs_opts']['mode'] = '0755'
 config_opts['plugin_conf']['tmpfs_opts']['keep_mounted'] = False
+{% endif %}
 
 
 config_opts['yum.conf'] = """

--- a/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
@@ -7,15 +7,6 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '{{ fedora_releasever }}'
 config_opts['package_manager'] = 'dnf'
 
-# Configure tmpfs to speed up mock
-config_opts['plugin_conf']['tmpfs_enable'] = True
-config_opts['plugin_conf']['tmpfs_opts'] = {}
-config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb'] = 1024
-config_opts['plugin_conf']['tmpfs_opts']['max_fs_size'] = '4g'
-config_opts['plugin_conf']['tmpfs_opts']['mode'] = '0755'
-config_opts['plugin_conf']['tmpfs_opts']['keep_mounted'] = False
-
-
 config_opts['yum.conf'] = """
 [main]
 keepcache=1

--- a/ansible/roles/utils/defaults/main.yml
+++ b/ansible/roles/utils/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-swapfile_size: 1G
+swapfile_size: 1000
 swapfile_file: /swapfile

--- a/ansible/roles/utils/tasks/enable_swap.yml
+++ b/ansible/roles/utils/tasks/enable_swap.yml
@@ -2,7 +2,7 @@
 - block:
   - name: write swap file
     command: >
-      fallocate -l {{ swapfile_size }} {{ swapfile_file }}
+      dd if=/dev/zero of={{ swapfile_file }} count={{ swapfile_size }} bs=1MB
     args:
       creates: "{{ swapfile_file }}"
       warn: false

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -1,5 +1,5 @@
 ---
-fedora_releasever: 31  # bump when fedora gets branched
+fedora_releasever: 33  # bump when fedora gets branched
 
 fedora_rawhide_template_dir: /tmp/rawhide_box
 base_box_url: "file://{{ fedora_rawhide_template_dir }}/latest.box"


### PR DESCRIPTION
- Bump rawhide release

- Replace fallocate with dd

    Due to a known bug in some filesystems where fallocate file is raising errors when trying to enable swap.

- Disable tmpfs plugin in mock    

    Build with it enabled is failing for Fedora 32 (Beta) and Rawhide (33).
    
    Stable `mock` versions as of today:
    mock-2.1-1.fc30
    mock-2.1-1.fc31
    mock-2.2-1.fc32
    mock-2.2-1.fc33

- Add tags to tasks for helping with template generation

    They can be used to when template generation need to be retried. E.g:
    ```
    $ ./create-template-box --skip-tags "upload_box,download_rawhide_box"
    ```
    
