### PR TITLE
prevent NetworkManager from updating /etc/resolv.conf

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -75,6 +75,20 @@
     src: hosts
     dest: /etc/hosts
 
+- name: prevent NetworkManager from updating/etc/resolv.conf
+  ini_file:
+    path: /etc/NetworkManager/NetworkManager.conf
+    section: main
+    option: dns
+    value: "none"
+  register: nm_conf
+
+- name: restart Networkmanager
+  service:
+    name: NetworkManager
+    state: restarted
+  when: nm_conf is changed
+
 - name: create /etc/resolv.conf file from template
   template:
     src: resolv.conf


### PR DESCRIPTION
NM periodically updates contents of /etc/resolv.conf putting
dhcp-provided DNS server on top of the list which breaks the
tests relying on DNS data provided by IPA server.