### PR TITLE
template: disable qemu session enabled by default

### DIFF
--- a/ansible/roles/box/prepare/templates/Vagrantfile.j2
+++ b/ansible/roles/box/prepare/templates/Vagrantfile.j2
@@ -9,6 +9,10 @@ Vagrant.configure(2) do |config|
         override.vm.box = "f{{ fedora_version }}"
     end
 
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.qemu_use_session = false
+    end
+
     config.vm.define "template"  do |template|
         template.vm.provider "libvirt" do |domain,override|
             domain.memory = 2048


### PR DESCRIPTION
Because of QEMU Session enabled by defailt, a failure occurs with if Vagrantfile contains:
` test_vm.vm.network :private_network, :ip => "172.16.0.2" ` or similar. Can be solved by
setting libvirt.qemu_use_session = false in Vagrantfile.

This commit adds the changes to the Vagrantfile jinja template.