### PR TITLE
Revert "prevent NetworkManager from updating /etc/resolv.conf"

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -75,20 +75,6 @@
     src: hosts
     dest: /etc/hosts
 
-- name: prevent NetworkManager from updating/etc/resolv.conf
-  ini_file:
-    path: /etc/NetworkManager/NetworkManager.conf
-    section: main
-    option: dns
-    value: "none"
-  register: nm_conf
-
-- name: restart Networkmanager
-  service:
-    name: NetworkManager
-    state: restarted
-  when: nm_conf is changed
-
 - name: create /etc/resolv.conf file from template
   template:
     src: resolv.conf


### PR DESCRIPTION
This reverts commit df43a00f66dac8daa6f8c6098706ce976096043d.

The commit is causing issues with dnf install. We are reverting this commit for now
until we can investigate what is causing the problem.

We have tested freeipa-pr-ci without this commit here:

https://github.com/bhavikbhavsar/freeipa/pulls

and all jobs are passing.