### PR TITLE
Force test to fail if provisioning fails

### DIFF
--- a/tasks/vagrant.py
+++ b/tasks/vagrant.py
@@ -57,7 +57,9 @@ def __setup_provision(task):
             task.execute_subtask(
                 VagrantUp(timeout=None))
             break
-        except PopenException:
+        except PopenException as exc:
+            if exc.task.returncode == -15:  # SIGTERM
+                raise
             if vagrant_up_retries:
                 logging.info(
                     "Retrying to bring the machine up, %s retries left",
@@ -74,7 +76,9 @@ def __setup_provision(task):
         try:
             task.execute_subtask(VagrantProvision(timeout=None))
             break
-        except PopenException:
+        except PopenException as exc:
+            if exc.task.returncode == -15:  # SIGTERM
+                raise
             if vagrant_provision_retries:
                 logging.info(
                     "Retrying provisioning, %s retries left" %


### PR DESCRIPTION
In the event of vagrant suspending hosts, runner rebooted or connection lost between vagrant hosts and runner PRCI fails and return error to Github.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/327

---
Log output when a vagrant machine is suspended:
http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/40022da4-a5f5-11ea-a617-5254000d65ad/

Log output if vagrant process is killed (SIGTERM):
http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/3617ddd6-a5fd-11ea-b190-5254000d65ad/runner.log.gz

