### PR TITLE
prevent NetworkManager from updating /etc/resolv.conf on ipa client

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -75,6 +75,22 @@
     src: hosts
     dest: /etc/hosts
 
+- when: inventory_hostname | regex_search("^client\d+$")
+  block:
+  - name: prevent NetworkManager from updating/etc/resolv.conf
+    ini_file:
+      path: /etc/NetworkManager/NetworkManager.conf
+      section: main
+      option: dns
+      value: "none"
+    register: nm_conf
+
+  - name: restart Networkmanager
+    service:
+      name: NetworkManager
+      state: restarted
+    when: nm_conf is changed
+
 - name: create /etc/resolv.conf file from template
   template:
     src: resolv.conf


### PR DESCRIPTION
NM periodically updates contents of /etc/resolv.conf putting
dhcp-provided DNS server on top of the list which breaks the
tests relying on DNS data provided by IPA server.

This patch is needed only for client machines as ipa-server-install
provides similar changes during IPA server installation.