### PR TITLE
Remove all freeipa-* packages from template

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -21,13 +21,21 @@
   with_items:
     - freeipa-client
     - freeipa-client-common
+    - freeipa-client-debuginfo
+    - freeipa-client-epn
+    - freeipa-client-samba
     - freeipa-common
     - freeipa-debuginfo
+    - freeipa-debugsource
+    - freeipa-healthcheck-core
     - freeipa-python-compat
+    - freeipa-selinux
     - freeipa-server
     - freeipa-server-common
+    - freeipa-server-debuginfo
     - freeipa-server-dns
     - freeipa-server-trust-ad
+    - freeipa-server-trust-ad-debuginfo
     - python3-ipaclient
     - python3-ipalib
     - python3-ipaserver


### PR DESCRIPTION
Those packages version numbers were crashing with the ones built for testing.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/378

Signed-off-by: Armando Neto <abiagion@redhat.com>