### PR TITLE
Enforce AES encryption

### DIFF
--- a/ansible/roles/windows/ad-root/tasks/main.yml
+++ b/ansible/roles/windows/ad-root/tasks/main.yml
@@ -5,6 +5,12 @@
     safe_mode_password: "{{ safe_mode_password }}"
   register: win_root_domain
 
+- name: Enforce AES encryption
+  win_security_policy:
+    section: Registry Values
+    key: "MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\SupportedEncryptionTypes"
+    value: 4,2147483640
+
 - name: Reboot Windows
   win_reboot:
     test_command: 'Get-ADUser -Filter {Name -eq "Administrator"}'

--- a/ansible/roles/windows/ad-subdomain/tasks/main.yml
+++ b/ansible/roles/windows/ad-subdomain/tasks/main.yml
@@ -34,5 +34,11 @@
     win_reboot:
       test_command: 'Get-ADUser -Filter {Name -eq "Administrator"}'
 
+- name: Enforce AES encryption
+  win_security_policy:
+    section: Registry Values
+    key: "MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\SupportedEncryptionTypes"
+    value: 4,2147483640
+
   - name: reset Administartor password
     win_shell: net user Administrator Secret123


### PR DESCRIPTION
As Fedora 32's default crypto policy does
not support RC4 any more, thus AES encryption
enabled on AD side.

Fixes: https://pagure.io/freeipa/issue/8294