### PR TITLE
Add support to change SELinux mode to enforcing

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -88,6 +88,13 @@
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.ipa.test"
 
+# Change selinux state if `selinux_enforcing: true` is set in test suite definition 
+- name: set selinux to enforcing
+  selinux:
+    policy: targeted
+    state: enforcing
+  when: selinux_enforcing is defined and selinux_enforcing
+
 - include_role:
     name: utils
     tasks_from: enable_swap

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -247,11 +247,12 @@ class RunPytest(JobTask):
 
     def __init__(self, template, build_url, test_suite, topology=None,
                  timeout=constants.RUN_PYTEST_TIMEOUT, update_packages=False,
-                 xmlrpc=False, **kwargs):
+                 xmlrpc=False, selinux_enforcing=False, **kwargs):
         super(RunPytest, self).__init__(template, timeout=timeout, **kwargs)
         self.build_url = build_url + '/'
         self.test_suite = test_suite
         self.update_packages = update_packages
+        self.selinux_enforcing = selinux_enforcing
         self.xmlrpc = xmlrpc
 
         if not topology:
@@ -275,7 +276,8 @@ class RunPytest(JobTask):
                 os.path.join(self.data_dir, 'vars.yml'),
                 dict(repofile_url=urllib.parse.urljoin(
                         self.build_url, 'rpms/freeipa-prci.repo'),
-                     update_packages=self.update_packages))
+                     update_packages=self.update_packages,
+                     selinux_enforcing=self.selinux_enforcing))
         except (OSError, IOError) as exc:
             msg = "Failed to prepare test config files"
             logging.debug(exc, exc_info=True)

--- a/templates/ad.vars.yml
+++ b/templates/ad.vars.yml
@@ -1,6 +1,7 @@
 ---
 repofile_url: {{ repofile_url }}
 update_packages: {{ update_packages }}
+selinux_enforcing: {{ selinux_enforcing }}
 
 ansible_python_interpreter: /usr/bin/python3
 

--- a/templates/run_pytest.vars.yml
+++ b/templates/run_pytest.vars.yml
@@ -1,5 +1,6 @@
 ---
 repofile_url: {{ repofile_url }}
 update_packages: {{ update_packages }}
+selinux_enforcing: {{ selinux_enforcing }}
 
 ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
Setting `selinux_enforcing: true` as an argument to a job definition will change the SELinux mode to `enforcing` during provisioning phase.

Issue #391 

Testing run: https://github.com/netoarmando/freeipa/pull/60