### PR TITLE
Increase memory required by vm

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -21,7 +21,7 @@ Vagrant.configure(2) do |config|
         # WARNING: Do not overcommit CPUs, it causes issues during
         # provisioning, when RPMs are installed
         domain.cpus = 2
-        domain.memory = 2400
+        domain.memory = 2750
 
         # Nested virtualization options
         domain.nested = true


### PR DESCRIPTION
New check added by commit https://pagure.io/freeipa/c/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce?branch=master
requires 1.6GB available.

Setting the same amount as used by other vms without any issue.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/393

Signed-off-by: Armando Neto <abiagion@redhat.com>

---

Test run: https://github.com/freeipa-pr-ci2/freeipa/pull/411