### PR TITLE
Update settings for Fedora 33

### DIFF
--- a/ansible/vars/fedora/33.yml
+++ b/ansible/vars/fedora/33.yml
@@ -1,10 +1,3 @@
 ---
-fedora_releasever: 33  # Fedora 33 is still in Beta
-nightly_compose: true
-
-fedora_nightly_template_dir: /tmp/f33_box
-base_box_url: "file://{{ fedora_nightly_template_dir }}/latest.box"
-
-fedora_nightly_images_remote_dir: https://dl.fedoraproject.org/pub/fedora/linux/development/33/Cloud/x86_64/images/
-
-# repo_rawhide_enabled: 1
+fedora_releasever: 33
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-33-1.2.x86_64.vagrant-libvirt.box


### PR DESCRIPTION
Fedora 33 was released, nightly composes are not necessary for it anymore.

Signed-off-by: Armando Neto <abiagion@redhat.com>