### PR TITLE
Provision machine: do not install freeipa-fas package

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -37,6 +37,8 @@
     name:
       - freeipa-*
       - python*-ipatests
+    exclude:
+      - freeipa-fas
   register: result
   until: result.rc == 0
   retries: 3


### PR DESCRIPTION
The freeipa-fas package must not be installed when running PRCI tests.
See the issues triggered by its presence:
https://pagure.io/freeipa/issue/8570
https://pagure.io/freeipa/issue/8569

Fixes: https://github.com/freeipa/freeipa-pr-ci/issues/400