### PR TITLE
Normalize rawhide definitions + Improve tool used to store templates

### DIFF
--- a/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
@@ -27,7 +27,7 @@ best=1
 
 [freeipa_copr]
 name=Copr repo @freeipa/freeipa-{{ freeipa_version }}
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@freeipa/freeipa-{{ freeipa_version }}/fedora-$releasever-$basearch/
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@freeipa/freeipa-{{ freeipa_version }}/fedora-rawhide-$basearch/
 type=rpm-md
 skip_if_unavailable=True
 gpgcheck=1
@@ -43,9 +43,20 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=$basearch
 failovermethod=priority
 enabled={{ repo_rawhide_enabled }}
 
+[group_389ds-389-ds-base-nightly]
+name=Copr repo for 389-ds-base-nightly owned by @389ds
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@389ds/389-ds-base-nightly/fedora-rawhide-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/@389ds/389-ds-base-nightly/pubkey.gpg
+repo_gpgcheck=0
+enabled={{ repo_389ds_testing_enabled }}
+enabled_metadata=1
+
 [group_pki-master]
 name=Copr repo for master owned by @pki
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/master/fedora-$releasever-$basearch/
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/master/fedora-rawhide-$basearch/
 type=rpm-md
 skip_if_unavailable=True
 gpgcheck=1

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -9,3 +9,5 @@ base_box_url: "file://{{ fedora_nightly_template_dir }}/latest.box"
 fedora_nightly_images_remote_dir: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/x86_64/images/
 
 repo_rawhide_enabled: 1
+repo_pki_master_enabled: 0
+repo_389ds_testing_enabled: 0


### PR DESCRIPTION
- Print and compare checksum when adding new box
>     Update script used to download a box to the locally hosted Vagrant
>     catalog to compare box's sha1sum with the one availble on the original
>     registry, saving time when publishing new box templates.

- Normalize Rawhide definitions

>     * Update COPR repos for rawhide to don't use release numbers, build stage
>     was failing in recent (f34) release target.
> 
>     * Add 389 COPR repo to rawhide mock definition, this way branched and
>     rawhide definitions look the same.
> 
>     * Include disabled variables to rawhide.yml to provide an easier way to
>     check what's availble when building a new template.
