### PR TITLE
Modernize spec file modifications

### DIFF
--- a/ansible/roles/builder/build/tasks/create_spec.yml
+++ b/ansible/roles/builder/build/tasks/create_spec.yml
@@ -1,15 +1,9 @@
 ---
-- name: add autoreconf to spec file
-  lineinfile:
-    path: /root/freeipa/freeipa.spec.in
-    insertafter: "^%setup"
-    line: autoreconf -if
-
 - name: change version in spec file
-  lineinfile:
+  replace:
     path: /root/freeipa/freeipa.spec.in
-    regexp: "^Version:"
-    line: "Version:        {{ build_version }}"
+    regexp: '^(%define IPA_VERSION) @VERSION@'
+    replace: '\1 {{ build_version }}'
 
 - name: create directory for spec file
   file:


### PR DESCRIPTION
FreeIPA spec file template already contains autoconf use, no need to add
another one.

Do not replace Version: line, replace @VERSION@ in IPA_VERSION
definition alone. IPA_VERSION macro is reused across the spec file.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>