### PR TITLE
Fix Fedora 33 DNS forwarder

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
 - block:
-    - name: get DNS server from resolv.conf
+    - name: get DNS server from resolv.conf (fedora <= 32)
       shell: awk '$1 == "nameserver" {print $2; exit}' /etc/resolv.conf
       register: dns_server
+      when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('32', '<=')
+
+    - name: get DNS server from resolvectl (fedora >= f33)
+      shell: "resolvectl status | grep 'Current DNS Server' | awk -F': ' '{print $2}'"
+      register: dns_server
+      when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('33', '>=')
 
     - name: set dns forwarder fact
       set_fact:


### PR DESCRIPTION
Fedora 33 switched its default DNS resolver to systemd-resolved, previously the task was getting the DNS server from /etc/resolv.conf, but for Fedora 33 that value is a loopback, breaking IPA installation because that address is used to define a DNS forwarder.


Testing this here: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/f6a1b546-38be-11eb-95c6-5254000d65ad/