### PR TITLE
Collect mock --buildsrpm logs

### DIFF
--- a/ansible/roles/builder/collect/tasks/main.yml
+++ b/ansible/roles/builder/collect/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
-- name: gather logs
-  shell: mv /root/rpmbuild/RPMS/*.log /vagrant/
+- name: create log directories for mock build srpm and rpm
+  file:
+    path: '{{ item }}'
+    state: directory
+  with_items:
+    - /vagrant/build-srpms-logs
+    - /vagrant/build-rpms-logs
+
+- name: gather logs for SRPMS
+  shell: mv /root/rpmbuild/SRPMS/*.log /vagrant/build-srpms-logs
+
+- name: gather logs for RPMS
+  shell: mv /root/rpmbuild/RPMS/*.log /vagrant/build-rpms-logs
 
 - name: create rpms directory
   file:


### PR DESCRIPTION
Logs were collected when RPMs are built; however, if there was an issue while building SRPMs no logs were collected.

This creates two folders to store the logs for both stages.

---

* Successful build output: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/82da60de-35aa-11eb-b65a-5254000d65ad/
* Forced error during `builder/build : create srpm`: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/c13a7846-35af-11eb-b65a-5254000d65ad/ 
* Forced error during `builder/build : create rpms`: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/716598c4-35b8-11eb-b65a-5254000d65ad/ 