### PR TITLE
Fix Ansible skipped variable when registering dns_server

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -2,17 +2,23 @@
 - block:
     - name: get DNS server from resolv.conf (fedora <= 32)
       shell: awk '$1 == "nameserver" {print $2; exit}' /etc/resolv.conf
-      register: dns_server
+      register: dns_server_resolv_conf
       when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('32', '<=')
 
     - name: get DNS server from resolvectl (fedora >= f33)
       shell: "resolvectl status | grep 'Current DNS Server' | awk -F': ' '{print $2}'"
-      register: dns_server
+      register: dns_server_resolvectl
       when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('33', '>=')
 
-    - name: set dns forwarder fact
+    - name: set dns forwarder fact (fedora <= 32)
       set_fact:
-        dns_forwarder: "{{ dns_server.stdout }}"
+        dns_forwarder: "{{ dns_server_resolv_conf.stdout }}"
+      when: dns_server_resolv_conf is not skipped
+
+    - name: set dns forwarder fact (fedora >= f33)
+      set_fact:
+        dns_forwarder: "{{ dns_server_resolvectl.stdout }}"
+      when: dns_server_resolvectl is not skipped
 
     # https://github.com/ansible/ansible/issues/56243
     - name: ensure file already exists at template dest to work around 'invalid selinux context' issue

--- a/ansible/roles/machine/provision/templates/ipa-test-config.yaml
+++ b/ansible/roles/machine/provision/templates/ipa-test-config.yaml
@@ -5,7 +5,7 @@ admin_password: Secret.123
 debug: false
 dirman_dn: cn=Directory Manager
 dirman_password: Secret.123
-dns_forwarder: {{ dns_server.stdout }}
+dns_forwarder: {{ dns_forwarder }}
 domains:
 - hosts:
 {% for host in groups['all'] %}


### PR DESCRIPTION
An additional task was necessary to check whether var was skipped or not.

From Ansible doc:
> Ansible always registers something in a registered variable for
> every host, even on hosts where a task fails or Ansible skips a task
> because a condition is not met.

Signed-off-by: Armando Neto <abiagion@redhat.com>

---

This is a follow-up of https://github.com/freeipa/freeipa-pr-ci/pull/407 because of an error reported at https://github.com/freeipa-pr-ci2/freeipa/pull/576#issuecomment-741628984.

Test execution: (https://github.com/netoarmando/freeipa/pull/66)

* `fedora-latest-f32/test_upgrade`: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/3c0275d8-3a60-11eb-b478-5254000d65ad
* `fedora-latest-f33/test_upgrade`: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/917778e4-3a63-11eb-b478-5254000d65ad