### PR TITLE
Fix resolvectl task returning white spaces

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -6,7 +6,7 @@
       when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('32', '<=')
 
     - name: get DNS server from resolvectl (fedora >= f33)
-      shell: "resolvectl status | grep 'Current DNS Server' | awk -F': ' '{print $2}'"
+      shell: "resolvectl dns | grep -m1 ': [1-9]' | awk -F': ' '{print $2}' | cut -d' ' -f 1"
       register: dns_server_resolvectl
       when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('33', '>=')
 
@@ -102,7 +102,7 @@
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.ipa.test"
 
-# Change selinux state if `selinux_enforcing: true` is set in test suite definition 
+# Change selinux state if `selinux_enforcing: true` is set in test suite definition
 - name: set selinux to enforcing
   selinux:
     policy: targeted


### PR DESCRIPTION
Replace task command to fetch DNS sever from `resolvectl dns` command, this will not return whitespaces.
Execute `grep -m1` to limit the number of lines to 1.
Execute `tr` to remove possible spaces.

Issue https://github.com/freeipa/freeipa-pr-ci/issues/410

---

Test runs:
- `fedora-32/test_webui_users`: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/7f901ebe-3e24-11eb-9129-5254000d65ad
- `fedora-33/test_webui_users`: http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/ccc97ac6-3e2a-11eb-9129-5254000d65ad
- `fedora-rawhide/test_webui_users`" http://freeipa-org-pr-ci.s3-website.eu-central-1.amazonaws.com/jobs/d0da5f62-3e30-11eb-9129-5254000d65ad