### PR TITLE
Do not write resolv.conf when provisioning test VMs

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -89,15 +89,6 @@
     src: hosts
     dest: /etc/hosts
 
-- name: create /etc/resolv.conf file from template
-  template:
-    src: resolv.conf
-    dest: /etc/resolv.conf
-
-# - name: set hostname
-#   hostname:
-#     name: "{{ inventory_hostname }}.ipa.test"
-
 # workaround for https://github.com/ansible/ansible/issues/19814
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.ipa.test"

--- a/ansible/roles/machine/provision/templates/resolv.conf
+++ b/ansible/roles/machine/provision/templates/resolv.conf
@@ -1,6 +1,0 @@
-search ipa.test
-{% for host in groups['all'] %}
-{% if host.startswith('master') or host.startswith('replica') %}
-nameserver {{ hostvars[host]['ansible_default_ipv4']['address'] }}
-{% endif %}
-{% endfor %}


### PR DESCRIPTION
File /etc/resolv.conf should not be edited in PR-CI.

* On distros that use NetworkManager to manage resolvers (i.e. Fedora 32)
  it is useless as NM overwrites contents of /etc/resolv.conf.
* On distros where user manages resolvers by editing resolv.conf this
  would break  tests which do packages installation before IPA server
  installation. As resolv.conf created by ansible contains only records
  for IPA server and replicas, package manager will not be able to
  resolve repository host name.
* On distros that use systemd-resolved (i.e. Fedora 33) /etc/resolv.conf
  is a symlink to a file generated by resolved. NM does not alter
  symlinks by design, but PR-CI replaces symlink with a regular file and
  NM starts to manage /etc/resolv.conf which creates a non-standard
  system installation.