### PR TITLE
Fix autocleaner

### DIFF
--- a/autocleaner.py
+++ b/autocleaner.py
@@ -149,7 +149,7 @@ def prune_exports_file(prune_dirs):
     exports.close()
 
     # sync exportfs before deleting the folders
-    subprocess.run(['exportfs', '-ar'], timeout=TIMEOUT)
+    subprocess.run(['/usr/sbin/exportfs', '-ar'], timeout=TIMEOUT)
 
     return entries_deleted
 

--- a/autocleaner.py
+++ b/autocleaner.py
@@ -104,11 +104,12 @@ def get_old_job_dirs(max_days):
     """
     old_job_dirs = []
     max_days = datetime.timedelta(max_days)
+    now = datetime.datetime.now()
     for folder in os.scandir(JOBS_DIR):
         if folder.is_dir():
             mtime = datetime.datetime.fromtimestamp(
                 os.path.getmtime(folder.path))
-            if mtime - datetime.datetime.now() < max_days:
+            if now - mtime > max_days:
                 old_job_dirs.append(folder.path)
     return old_job_dirs
 


### PR DESCRIPTION
Fixing two issues in autocleaner.py:
* Crash while removing old jobs dirs (#422)
* `--jobs_dir_exp` option was not respected, all jobs dirs were removed