### PR TITLE
Add Fedora 34 template and bump rawhide

### DIFF
--- a/ansible/vars/fedora/34.yml
+++ b/ansible/vars/fedora/34.yml
@@ -1,0 +1,13 @@
+---
+fedora_releasever: 34  # bump when fedora gets branched
+
+nightly_compose: true
+
+fedora_nightly_template_dir: /tmp/f34_box
+base_box_url: "file://{{ fedora_nightly_template_dir }}/latest.box"
+
+fedora_nightly_images_remote_dir: https://dl.fedoraproject.org/pub/fedora/linux/development/34/Cloud/x86_64/images/
+
+# repo_rawhide_enabled: 1
+repo_pki_master_enabled: 0
+repo_389ds_testing_enabled: 0

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -1,5 +1,5 @@
 ---
-fedora_releasever: 34  # bump when fedora gets branched
+fedora_releasever: 35  # bump when fedora gets branched
 
 nightly_compose: true
 


### PR DESCRIPTION
Fedora 34 is still under development, this is a temporary definition file.

Fedora Rawhide now targets Fedora 35.

Signed-off-by: Armando Neto <abiagion@redhat.com>