### PR TITLE
Update settings for Fedora 34

### DIFF
--- a/ansible/vars/fedora/34.yml
+++ b/ansible/vars/fedora/34.yml
@@ -1,13 +1,3 @@
 ---
 fedora_releasever: 34  # bump when fedora gets branched
-
-nightly_compose: true
-
-fedora_nightly_template_dir: /tmp/f34_box
-base_box_url: "file://{{ fedora_nightly_template_dir }}/latest.box"
-
-fedora_nightly_images_remote_dir: https://dl.fedoraproject.org/pub/fedora/linux/development/34/Cloud/x86_64/images/
-
-# repo_rawhide_enabled: 1
-repo_pki_master_enabled: 0
-repo_389ds_testing_enabled: 0
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-34-1.2.x86_64.vagrant-libvirt.box


### PR DESCRIPTION
Fedora 34 was released, nightly composes are not necessary for it anymore.

Signed-off-by: Armando Neto <abiagion@redhat.com>