### PR TITLE
Schedule nightly PR: add a review request

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -3,12 +3,31 @@ basedir: /root/openclose_pr
 
 nightly_jobs:
   - name: testing_master_latest
-    weekdays: "1,3,5"
+    weekdays: "1"
     hour: "23"
     minute: "00"
     flow: "ci"
     branch: "master"
     prci_config: "nightly_latest.yaml"
+    reviewer: wladich
+
+  - name: testing_master_latest
+    weekdays: "3,5"
+    hour: "23"
+    minute: "00"
+    flow: "ci"
+    branch: "master"
+    prci_config: "nightly_latest.yaml"
+    reviewer: flo-renaud
+
+  - name: testing_master_previous
+    weekdays: "2"
+    hour: "23"
+    minute: "00"
+    flow: "ci"
+    branch: "master"
+    prci_config: "nightly_previous.yaml"
+    reviewer: miskopo
 
   - name: testing_master_previous
     weekdays: "2,4"
@@ -17,6 +36,7 @@ nightly_jobs:
     flow: "ci"
     branch: "master"
     prci_config: "nightly_previous.yaml"
+    reviewer: ssidhaye
 
   - name: testing_master_rawhide
     weekdays: "6"
@@ -25,6 +45,7 @@ nightly_jobs:
     flow: "ci"
     branch: "master"
     prci_config: "nightly_rawhide.yaml"
+    reviewer: flo-renaud
 
   - name: testing_ipa-4.6
     weekdays: "7"
@@ -33,6 +54,7 @@ nightly_jobs:
     flow: "ci"
     branch: "ipa-4-6"
     prci_config: "nightly_ipa-4-6.yaml"
+    reviewer: miskopo
 
   - name: testing_ipa-4.9_latest
     weekdays: "6"
@@ -41,6 +63,7 @@ nightly_jobs:
     flow: "ci"
     branch: "ipa-4-9"
     prci_config: "nightly_ipa-4-9_latest.yaml"
+    reviewer: miskopo
 
   - name: testing_ipa-4.9_previous
     weekdays: "6"
@@ -49,6 +72,7 @@ nightly_jobs:
     flow: "ci"
     branch: "ipa-4-9"
     prci_config: "nightly_ipa-4-9_previous.yaml"
+    reviewer: menonsudhir
 
   - name: testing_master_pki
     weekdays: "7"
@@ -57,6 +81,7 @@ nightly_jobs:
     flow: "pki"
     branch: "master"
     prci_config: "nightly_latest_pki.yaml"
+    reviewer: amore17
 
   - name: testing_master_389ds
     weekdays: "6"
@@ -65,6 +90,7 @@ nightly_jobs:
     flow: "389ds"
     branch: "master"
     prci_config: "nightly_latest_389ds.yaml"
+    reviewer: flo-renaud
 
   - name: testing_master_testing
     weekdays: "7"
@@ -73,6 +99,7 @@ nightly_jobs:
     flow: "testing"
     branch: "master"
     prci_config: "nightly_latest_testing.yaml"
+    reviewer: fcami
 
   - name: testing_master_latest_selinux
     weekdays: "1"
@@ -81,6 +108,7 @@ nightly_jobs:
     flow: "ci"
     branch: "master"
     prci_config: "nightly_latest_selinux.yaml"
+    reviewer: wladich
 
   - name: testing_master_testing_selinux
     weekdays: "3"
@@ -89,6 +117,7 @@ nightly_jobs:
     flow: "testing"
     branch: "master"
     prci_config: "nightly_latest_testing_selinux.yaml"
+    reviewer: fcami
 
   - name: testing_ipa-4.9_latest_selinux
     weekdays: "5"
@@ -97,3 +126,4 @@ nightly_jobs:
     flow: "ci"
     branch: "ipa-4-9"
     prci_config: "nightly_ipa-4-9_latest_selinux.yaml"
+    reviewer: miskopo

--- a/ansible/roles/automation/nightly_pr/tasks/main.yml
+++ b/ansible/roles/automation/nightly_pr/tasks/main.yml
@@ -14,6 +14,7 @@
            --branch {{ item.branch }}
            --prci_config {{ prci_def_dir }}/{{ item.prci_config }}
            --pr_against_upstream {{ pr_against_upstream | bool }}
+           --reviewer {{ item.reviewer }}
     user: root
     state: present
   with_items: "{{ nightly_jobs }}"

--- a/github/open_close_pr.py
+++ b/github/open_close_pr.py
@@ -291,6 +291,10 @@ class AutomatedPR(object):
                 pr = self.repo.create_pull(pr_title, self.args.branch,
                                            self.args.id)
 
+            # Request a review
+            if self.args.reviewer:
+                pr.create_review_requests(reviewers=[self.args.reviewer])
+
             logger.info("PR %s created", pr.number)
         except github3.GitHubError as error:
             logger.error(error.errors)
@@ -356,6 +360,11 @@ def create_parser():
              "FreeIPA repo. E.g: ipatests/prci_definitions/gating"
     )
 
+    nightly.add_argument(
+        '--reviewer', type=str, required=False,
+        help="Github name of the user from which a review will be requested. "
+             "E.g: flo-renaud"
+    )
     template = commands.add_parser(
         'open_template_pr', parents=[parent_parser],
         description="Opens a PR for bumping PRCI template version"


### PR DESCRIPTION
Add a --reviewer option to the open_nightly_pr subcommand
of open_close_pr script.
When a --reviewer is provided, a review of the nightly PR
is requested from the reviewer. This helps tracking who should
investigate which nightly.