### PR TITLE
Execute testing_master_testing on Wednesdays

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -93,8 +93,8 @@ nightly_jobs:
     reviewer: flo-renaud
 
   - name: testing_master_testing
-    weekdays: "7"
-    hour: "2"
+    weekdays: "3"
+    hour: "8"
     minute: "00"
     flow: "testing"
     branch: "master"


### PR DESCRIPTION
Change the day of the week testing_master_testing is executed
so that it is the same day as testing_master_testing_selinux.

Signed-off-by: François Cami <fcami@redhat.com>