### PR TITLE
Nightly tests: merge testing_master_previous in the crontab

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -21,16 +21,7 @@ nightly_jobs:
     reviewer: flo-renaud
 
   - name: testing_master_previous
-    weekdays: "2"
-    hour: "23"
-    minute: "00"
-    flow: "ci"
-    branch: "master"
-    prci_config: "nightly_previous.yaml"
-    reviewer: miskopo
-
-  - name: testing_master_previous
-    weekdays: "4"
+    weekdays: "2,4"
     hour: "23"
     minute: "00"
     flow: "ci"


### PR DESCRIPTION
commit 6f007d5 changed the nightly owner for one of the
testing_master_previous runs, but this results in the same
key used for both runs.

Merge them instead (they have the same owner) and define the
2 weekdays in a single crontab entry.