### PR TITLE
Fix ipa-4-6-27 image

### DIFF
--- a/ansible/roles/machine/cleanup/tasks/clean_vagrant_temp.yml
+++ b/ansible/roles/machine/cleanup/tasks/clean_vagrant_temp.yml
@@ -1,0 +1,6 @@
+---
+- name: remove temporary interface from f27
+  file:
+    path: /etc/sysconfig/network-scripts/ifcfg-eth1
+    state: absent
+  when: fedora_version == '27'

--- a/ansible/roles/machine/cleanup/tasks/main.yml
+++ b/ansible/roles/machine/cleanup/tasks/main.yml
@@ -4,5 +4,6 @@
 - include: clean_dhcp_state.yml
 - include: clean_mac_addresses.yml
 - include: clean_logs.yml
+- include: clean_vagrant_temp.yml
 - include: clean_history.yml
 

--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -2,6 +2,6 @@
 selinux_mode: permissive
 copr_repo: "@freeipa/freeipa-master"
 python_packages_to_install:
-  - pytest-html
+  - pytest-html==1.22.0
   - nose
   - selenium

--- a/ansible/roles/machine/setup/tasks/configuration.yml
+++ b/ansible/roles/machine/setup/tasks/configuration.yml
@@ -10,6 +10,7 @@
     - fedora
     - updates
     - updates-testing
+    - fedora-cisco-openh264
 
 - name: enable selected repositories
   shell: "dnf config-manager --set-enabled {{ item.key }}"

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -40,6 +40,7 @@
     - python3-ipalib
     - python3-ipaserver
     - python3-ipatests
+  ignore_errors: yes
 
 # this can be removed when python2 is gone completly
 - name: remove freeipa python2 packages seperately
@@ -60,6 +61,7 @@
       - xorg-x11-server-Xvfb
       - firefox
       - python3-paramiko
+      - python3-pip
       - firewalld
       - nfs-utils
 


### PR DESCRIPTION
**Changes**: 
* Remove left-over file (/etc/sysconfig/network-scripts/ifcfg-eth1) used by Vagrant during image generation.
* Pin `pytest-html` version to fix conflict when dnf updates all packages.
* Remove unnecessary `fedora-cisco-openh264` repo.

Issue: https://pagure.io/freeipa/issue/8959

---

Image generated after this: https://app.vagrantup.com/freeipa/boxes/ci-ipa-4-6-f27/versions/1.0.5/
Pull request testing it: https://github.com/freeipa-pr-ci2/freeipa/pull/1247