### PR TITLE
Install kernel-modules package

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -64,6 +64,7 @@
       - python3-pip
       - firewalld
       - nfs-utils
+      - kernel-modules
 
 - name: install Ansible dependencies
   dnf:


### PR DESCRIPTION
Add package to enable `cifs` module.

Issue: https://pagure.io/freeipa/issue/9087

Signed-off-by: Armando Neto <abiagion@redhat.com>