### PR TITLE
Add support for FIPS mode

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -103,6 +103,23 @@
     state: enforcing
   when: selinux_enforcing is defined and selinux_enforcing
 
+- block:
+    - name: install FIPS dependencies
+      dnf:
+        state: latest
+        name:
+          - fips-mode-setup
+
+    - name: run fips-mode-setup
+      shell: fips-mode-setup --enable
+
+    - name: create REBOOT_READY file
+      file:
+        path: "/vagrant/REBOOT_READY"
+        state: touch
+
+  when: fips is defined and fips
+
 - include_role:
     name: utils
     tasks_from: enable_swap

--- a/templates/run_pytest.vars.yml
+++ b/templates/run_pytest.vars.yml
@@ -3,5 +3,5 @@ repofile_url: {{ repofile_url }}
 update_packages: {{ update_packages }}
 selinux_enforcing: {{ selinux_enforcing }}
 caless: {{ caless | default(false) }}
-
+fips: {{ fips | default(false) }}
 ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
Introduce fips bool variable and its handling, implement FIPS setup to          
provisioning playbooks. Include check to ensure that FIPS mode is                
initialized correctly prior to launching the test phase.                           
                                                                                   
Add support for reloading all machines from vagrant's side (this halts             
all the machines, starts them up and reestablishes shared folder).                 
Reload can be triggered by creating a REBOOT_READY file in the vagrant            
shared folder before the test phase (either in provisioning or upping             
phase).                                                                           
                                                                                
Signed-off-by: Michal Polovka <mpolovka@redhat.com>