### PR TITLE
Fix deprecated import shortcut

### DIFF
--- a/tasks/common.py
+++ b/tasks/common.py
@@ -1,11 +1,11 @@
 import abc
-import collections
 import errno
 import logging
 import os
 import signal
 import subprocess
 import threading
+from collections.abc import Callable as AbcCallable
 from typing import Callable, List, Text
 
 import jinja2
@@ -60,7 +60,7 @@ class PopenException(TaskException):
             error=self.task.returncode)
 
 
-class Task(collections.Callable):
+class Task(AbcCallable):
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, timeout=120):


### PR DESCRIPTION
Python 3.8.7 was already printing warning about that when import Callable from collections:

```
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated since Python 3.3,
and in 3.9 it will stop working.
```

Fedora 35 runners have Python 3.10 so this is needed to support PR-CI.

Signed-off-by: Armando Neto <abiagion@redhat.com>