### PR TITLE
Disable bash bracketed-paste mode

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -105,4 +105,8 @@
 
 - include_role:
     name: utils
+    tasks_from: bash_settings
+
+- include_role:
+    name: utils
     tasks_from: enable_swap

--- a/ansible/roles/utils/tasks/bash_settings.yaml
+++ b/ansible/roles/utils/tasks/bash_settings.yaml
@@ -1,0 +1,12 @@
+---
+- block:
+  - name: disable bracketed bash paste mode
+    shell: bind 'set enable-bracketed-paste off'
+  - name: permanently system-wide disable bracketed bash paste mode
+    shell: echo 'set enable-bracketed-paste off' >> /etc/inputrc
+  - name: check setting
+    shell: cat /etc/inputrc | grep enable-bracketed-paste
+    register: bracketed_paste_mode
+  - name: display enable-bracketed-paste mode
+    debug:
+      msg: "{{ bracketed_paste_mode }}"


### PR DESCRIPTION
enable-bracketed-paste is enabled by default since bash-5.1. When set to On,
readline will configure the terminal in a way that will enable it to insert
each paste into the editing buffer as a single string of characters, instead
of treating each character as if it had been read from the  keyboard. This is
affecting some of our automated tests:

pexpect.exceptions.ExceptionPexpect: Program exited with an unexpected state:
Unexpected output at program exit: '  \x1b[?2004l\r'

This commit adds bash_settings task group as part of utils role so that
we can disable back bracketed-paste mode and maybe other settings in the
future.