### PR TITLE
Disable swapfile creation if not Fedora <= 34

### DIFF
--- a/ansible/roles/utils/tasks/enable_swap.yml
+++ b/ansible/roles/utils/tasks/enable_swap.yml
@@ -39,3 +39,4 @@
       passno: '0'
       dump: '0'
       state: present
+  when: ansible_distribution == 'Fedora' and ansible_distribution_version is version('34', '<=')


### PR DESCRIPTION
Fedora cloud images started to come with swap enabled in version 35.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/456

Test results: https://github.com/netoarmando/freeipa/pull/69