### PR TITLE
Ignore errors from gathering list of ifcfg files

### DIFF
--- a/ansible/roles/machine/cleanup/tasks/clean_mac_addresses.yml
+++ b/ansible/roles/machine/cleanup/tasks/clean_mac_addresses.yml
@@ -1,7 +1,8 @@
 ---
 - name: gather list of ifcfg files
-  raw: find /etc/sysconfig/network-scripts/ -type f -name "ifcfg-*"
+  raw: find /etc/sysconfig/network-scripts/ -type f -name "ifcfg-*" 2>/dev/null
   register: ifcfg_files
+  ignore_errors: yes
 
 - name: remove HWADDR line from ifcfg files
   lineinfile:


### PR DESCRIPTION
Fedora 36 removes the NetworkManager legacy configuration file support
(ifcfg files). As the ifcfg files are not present for Fedora 36, the
automation to create new vagrant template boxes is broken.

With this commit, errors from clean_mac_addresses.yml when trying to
fetch ifcfg files are simply ignored.

Signed-off-by: Francisco Trivino <ftrivino@redhat.com>