### PR TITLE
Set custom COPR repo via test definition files

### DIFF
--- a/ansible/roles/builder/build/tasks/create_rpms.yml
+++ b/ansible/roles/builder/build/tasks/create_rpms.yml
@@ -2,6 +2,8 @@
 - name: create srpm
   shell: |
     mock --buildsrpm \
+      {% if copr is defined and copr %}--addrepo 'https://download.copr.fedorainfracloud.org/results/{{ copr }}/fedora-$releasever-$basearch/'{% endif %}
+      {% if enable_testing_repo is defined and enable_testing_repo|bool %}--enablerepo updates-testing{% endif %}
       --spec /root/rpmbuild/SPECS/freeipa.spec \
       --sources /root/rpmbuild/SOURCES/freeipa-{{ build_version }}.tar.gz \
       --result /root/rpmbuild/SRPMS/
@@ -9,6 +11,8 @@
 - name: create rpms
   shell: |
     mock --rebuild /root/rpmbuild/SRPMS/*.src.rpm \
+      {% if copr is defined and copr %}--addrepo 'https://download.copr.fedorainfracloud.org/results/{{ copr }}/fedora-$releasever-$basearch/'{% endif %}
+      {% if enable_testing_repo is defined and enable_testing_repo|bool %}--enablerepo updates-testing{% endif %}
       --result /root/rpmbuild/RPMS/
 
 - name: remove srpm artifact from RPMS dir

--- a/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
@@ -65,43 +65,4 @@ failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ fedora_releasever }}-primary
 gpgcheck=1
 enabled={{ repo_updates_enabled }}
-
-[updates-testing]
-name=updates-testing
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
-failovermethod=priority
-enabled={{ repo_updates_testing_enabled }}
-
-[group_pki-10.6-nightly]
-name=Copr repo for 10.6-nightly owned by @pki
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/10.6-nightly/fedora-$releasever-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/@pki/10.6-nightly/pubkey.gpg
-repo_gpgcheck=0
-enabled={{ repo_pki_testing_enabled }}
-enabled_metadata=1
-
-[group_389ds-389-ds-base-nightly]
-name=Copr repo for 389-ds-base-nightly owned by @389ds
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@389ds/389-ds-base-nightly/fedora-$releasever-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/@389ds/389-ds-base-nightly/pubkey.gpg
-repo_gpgcheck=0
-enabled={{ repo_389ds_testing_enabled }}
-enabled_metadata=1
-
-[group_pki-master]
-name=Copr repo for master owned by @pki
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/master/fedora-$releasever-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/@pki/master/pubkey.gpg
-repo_gpgcheck=0
-enabled={{ repo_pki_master_enabled }}
-enabled_metadata=1
 """

--- a/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
@@ -43,26 +43,4 @@ name=rawhide
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=$basearch
 failovermethod=priority
 enabled={{ repo_rawhide_enabled }}
-
-[group_389ds-389-ds-base-nightly]
-name=Copr repo for 389-ds-base-nightly owned by @389ds
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@389ds/389-ds-base-nightly/fedora-rawhide-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/@389ds/389-ds-base-nightly/pubkey.gpg
-repo_gpgcheck=0
-enabled={{ repo_389ds_testing_enabled }}
-enabled_metadata=1
-
-[group_pki-master]
-name=Copr repo for master owned by @pki
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@pki/master/fedora-rawhide-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/@pki/master/pubkey.gpg
-repo_gpgcheck=0
-enabled={{ repo_pki_master_enabled }}
-enabled_metadata=1
 """

--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -40,6 +40,18 @@
     description: FreeIPA PR CI testing packages
     gpgcheck: no
 
+- name: "configure custom COPR repo ({{ copr }})"
+  shell: "dnf copr enable -y {{ copr }}"
+  args:
+    warn: false
+  when: copr is defined and copr
+
+- name: enable updates-testing repository
+  shell: "dnf config-manager --set-enabled updates-testing"
+  args:
+    warn: false
+  when: enable_testing_repo is defined and enable_testing_repo
+
 - name: update packages
   dnf:
     name: '*'

--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 selinux_mode: permissive
-copr_repo: "@freeipa/freeipa-master"
 python_packages_to_install:
   - pytest-html==1.22.0
   - nose

--- a/ansible/roles/machine/setup/tasks/configuration.yml
+++ b/ansible/roles/machine/setup/tasks/configuration.yml
@@ -17,7 +17,6 @@
   with_dict:
     fedora: "{{ repo_fedora_enabled }}"
     updates: "{{ repo_updates_enabled }}"
-    updates-testing: "{{ repo_updates_testing_enabled }}"
   when: fedora_version != 'rawhide' and item.value
 
 - name: configure rawhide repository
@@ -27,15 +26,3 @@
 - name: configure FreeIPA COPR repo
   shell: "dnf copr enable -y @freeipa/freeipa-{{ freeipa_version }}"
   when: repo_freeipa_copr_enabled
-
-- name: configure PKI COPR repo (master)
-  shell: "dnf copr enable -y @pki/master"
-  when: repo_pki_master_enabled
-
-- name: configure PKI COPR repo (nightly)
-  shell: "dnf copr enable -y @pki/10.6-nightly"
-  when: repo_pki_testing_enabled
-
-- name: configure 389-ds COPR repo (nightly)
-  shell: "dnf copr enable -y @389ds/389-ds-base-nightly"
-  when: repo_389ds_testing_enabled

--- a/doc/README.md
+++ b/doc/README.md
@@ -250,6 +250,8 @@ FreeIPA packages.
 ```yaml
       class: Build
       args:
+        enable_testing_repo: true
+        copr: '@pki/master'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-f26
@@ -270,6 +272,11 @@ Some of these arguments are common to all FreeIPA jobs.
 - `timeout`: Maximum allowed time in seconds. If the job is still running after
   this period of time passes, it will be killed, torn down and reported as an
   error.
+- `copr`: Custom COPR repo that will be enabled in `mock` (for Build stage) and
+  inside all vms.
+- `enable_testing_repo`: Same as `copr` but this enables `updates-testing` repo.
+- `update_packages`: This forces DNF to updates all packages when installing
+  dependencies. _This does not apply to Build stage._ __This is "mandatory" for non-build stages with `copr` or `enable_testing_repo` enabled.__
 
 There are also `Build` specific arguments.
 

--- a/templates/run_pytest.vars.yml
+++ b/templates/run_pytest.vars.yml
@@ -4,4 +4,6 @@ update_packages: {{ update_packages }}
 selinux_enforcing: {{ selinux_enforcing }}
 caless: {{ caless | default(false) }}
 fips: {{ fips | default(false) }}
+enable_testing_repo: {{ enable_testing_repo | default(false) }}
 ansible_python_interpreter: /usr/bin/python3
+{% if copr %}copr: "{{ copr }}"{% endif %}


### PR DESCRIPTION
Replace defined-during-image-build definitions of COPR repos with a "copr" and "enable_testing_repo" vars that can be set in the test definitions file.

E.g:

```
fedora-latest/build:
  requires: []
  priority: 100
  job:
    class: Build
    args:
      enable_testing_repo: true
      copr: '@pki/master'
      git_repo: '{git_repo}'
      git_refspec: '{git_refspec}'
      template: &ci-master-latest
        name: freeipa/ci-master-f35
        version: 0.0.5
      timeout: 1800
      topology: *build
```

Also, the "build" job needs to set those variables too.

And `update_packages` must be set to `True` when setting `enable_testing_repo` or `copr`; otherwise, packages available on those repos wouldn't be updated.