### PR TITLE
Add missing vars when testing with Windows topologies

### DIFF
--- a/templates/ad.vars.yml
+++ b/templates/ad.vars.yml
@@ -2,7 +2,9 @@
 repofile_url: {{ repofile_url }}
 update_packages: {{ update_packages }}
 selinux_enforcing: {{ selinux_enforcing }}
-
+caless: {{ caless | default(false) }}
+fips: {{ fips | default(false) }}
+enable_testing_repo: {{ enable_testing_repo | default(false) }}
 ansible_python_interpreter: /usr/bin/python3
-
+{% if copr %}copr: "{{ copr }}"{% endif %}
 testing_ad: true


### PR DESCRIPTION
`ad.vars.yaml` now has the same content as `webui.vars.yml` and r`un_pytest.vars.yml`; the former is a symlink to the latter.

`ad.var.yaml` needs to look the same, with one extra var: `testing_ad: true`.

Signed-off-by: Armando Neto <abiagion@redhat.com>