### PR TITLE
Add 'updates-testing' repo back to mock config

### DIFF
--- a/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-branched.cfg.j2
@@ -65,4 +65,12 @@ failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ fedora_releasever }}-primary
 gpgcheck=1
 enabled={{ repo_updates_enabled }}
+
+[updates-testing]
+name=updates-testing
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{{ fedora_releasever }}-primary
+gpgcheck=1
+enabled=0
 """


### PR DESCRIPTION
Removed in 4533d7bcf1fb4c407e2735fe5c0f6b0df6c5ecde by mistake, this is necessary (disabled by default) when running jobs with `enable_testing_repo = True`.

A new vagrant box will be provided with this fix.