### PR TITLE
Fix COPR and Python dependencies in Fedora Rawhide

### DIFF
--- a/ansible/roles/builder/build/tasks/create_rpms.yml
+++ b/ansible/roles/builder/build/tasks/create_rpms.yml
@@ -1,8 +1,15 @@
 ---
+- name: check if target system is running a branched release
+  command:
+    cmd: 'grep -qvi rawhide /etc/fedora-release'  # fails when rawhide
+  register: target_is_branched
+  changed_when: false
+  ignore_errors: true
+
 - name: create srpm
   shell: |
     mock --buildsrpm \
-      {% if copr is defined and copr %}--addrepo 'https://download.copr.fedorainfracloud.org/results/{{ copr }}/fedora-$releasever-$basearch/'{% endif %}
+      {% if copr is defined and copr %}--addrepo 'https://download.copr.fedorainfracloud.org/results/{{ copr }}/fedora-{{ 'rawhide' if target_is_branched.failed else '$releasever' }}-$basearch/'{% endif %}
       {% if enable_testing_repo is defined and enable_testing_repo|bool %}--enablerepo updates-testing{% endif %}
       --spec /root/rpmbuild/SPECS/freeipa.spec \
       --sources /root/rpmbuild/SOURCES/freeipa-{{ build_version }}.tar.gz \
@@ -11,7 +18,7 @@
 - name: create rpms
   shell: |
     mock --rebuild /root/rpmbuild/SRPMS/*.src.rpm \
-      {% if copr is defined and copr %}--addrepo 'https://download.copr.fedorainfracloud.org/results/{{ copr }}/fedora-$releasever-$basearch/'{% endif %}
+      {% if copr is defined and copr %}--addrepo 'https://download.copr.fedorainfracloud.org/results/{{ copr }}/fedora-{{ 'rawhide' if target_is_branched.failed else '$releasever' }}-$basearch/'{% endif %}
       {% if enable_testing_repo is defined and enable_testing_repo|bool %}--enablerepo updates-testing{% endif %}
       --result /root/rpmbuild/RPMS/
 

--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 selinux_mode: permissive
 python_packages_to_install:
-  - pytest-html==1.22.0
+  - pytest-html
   - nose
   - selenium


### PR DESCRIPTION
#### Fix COPR repo address in mock when in rawhide boxes

> When running rawhide Ansible's variable `ansible_distribution_release` is empty, it was expected to be `Rawhide`. So, instead of using that this change is adding a task to check the content of `/etc/fedora-release` file.

#### Install latest pytest-html

> Old 1.22.x version was Python 2.7 compatible.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/467

---

This has been tested here: https://github.com/netoarmando/freeipa/pull/71