### PR TITLE
Reinstall pip packages when updating packages

### DIFF
--- a/ansible/roles/machine/provision/defaults/main.yml
+++ b/ansible/roles/machine/provision/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 deploy_ipa_test_config: false
+python_packages_to_install: # same as machine/setup/defaults
+  - pytest-html
+  - nose
+  - selenium

--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -58,6 +58,12 @@
     state: latest
   when: update_packages is defined and update_packages
 
+- name: update pip packages
+  pip:
+    executable: pip3
+    name: "{{ python_packages_to_install }}"
+  when: update_packages is defined and update_packages
+
 - name: install freeipa packages
   dnf:
     state: latest

--- a/ansible/roles/machine/setup/defaults/main.yml
+++ b/ansible/roles/machine/setup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 selinux_mode: permissive
-python_packages_to_install:
+python_packages_to_install: # same as machine/provision/defaults
   - pytest-html
   - nose
   - selenium


### PR DESCRIPTION
When Python is updated in rawhide (e.g. new beta version) site-packages gets cleaned and packages installed via pip are lost.

Default list of packages is duplicated due to lack of a better approach to unify that across multiple roles.

Issue: https://github.com/freeipa/freeipa-pr-ci/issues/467

---

A new beta release of Python is available, so issue #467 wasn't fixed properly.

Blocks: https://github.com/freeipa/freeipa/pull/6342