### PR TITLE
fix: autocleaner failing on getting prci def files

### DIFF
--- a/autocleaner.py
+++ b/autocleaner.py
@@ -210,19 +210,17 @@ class PRCIDef():
         GraphQL query for getting all PRCI yaml job definition files
         """
         return {"query": """{
-      viewer {
-        repository(name: "freeipa") {
-          object(expression: "%s:%s") {
-          ... on Tree{
-            entries{
-              name
-              type
-              mode
+          repository(name: "freeipa", owner: "freeipa") {
+            object(expression: "%s:%s") {
+            ... on Tree{
+              entries{
+                name
+                type
+                mode
+              }
             }
           }
         }
-        }
-      }
     }""" % (self.branch, PRCI_DEF_DIR)}
 
     def get_prci_def_files(self):
@@ -233,7 +231,7 @@ class PRCIDef():
                             headers={'Authorization': 'bearer {}'.format(
                                 get_gh_token())})
         try:
-            files = res.json()['data']['viewer']['repository']['object']['entries']
+            files = res.json()['data']['repository']['object']['entries']
         except TypeError:
             logger.error(traceback.print_exc())
             logger.error('Could not get PRCI definition files from %s, please '

--- a/autocleaner.py
+++ b/autocleaner.py
@@ -232,6 +232,12 @@ class PRCIDef():
                                 get_gh_token())})
         try:
             files = res.json()['data']['repository']['object']['entries']
+            # filter out non-yaml and prci_checker files
+            files = [
+                f for f in files if
+                (f['name'].endswith('.yaml') or f['name'].endswith('.yml')) and
+                f['name'] != 'prci_jobs_spec.yaml'
+            ]
         except TypeError:
             logger.error(traceback.print_exc())
             logger.error('Could not get PRCI definition files from %s, please '

--- a/autocleaner.py
+++ b/autocleaner.py
@@ -122,10 +122,10 @@ def prune_exports_file(prune_dirs):
     """
     entries_deleted = []
     try:
-        if not os.geteuid()==0:
+        if not os.geteuid() == 0:
             print("\nUnable to prune /etc/exports. Must be run as root\n")
             return None
-    except:
+    except Exception:
         pass
 
     exports = open('/etc/exports', 'r+')


### PR DESCRIPTION
**fix(autocleaner): featching of prci def files from new branches**

the autocleaner was failing on fetching prci def files from branch
ipa-4-10.  This happened because the files were downloaded from
PR-CI user's freeipa fork and not from the main "freeipa" organization.

This happened as the query was starting with 'viewer' query, which
represents the currently logged-in user.

This patch is changing the query to always check the main
freeipa/freeipa repo and thus it won't fail if the token owner repo
doesn't contain some new branch.

**fix(autocleaner): filter out prci_checker files**

PR: https://github.com/freeipa/freeipa/pull/6301

Added new files to prci_definitions folder which are not PR-CI defition
files. Thus these needs to be filtered out otherwise the autocleaner
will crash on processing those files.

**style(autocleaner): fix linter errors**

Which I was getting by flake8 in VS code.