### PR TITLE
Allow proper github username for carma12

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -7,7 +7,7 @@
 - apophys
 - b3lix
 - bhavikbhavsar
-- carlmart
+- carma12
 - celestian
 - ckelleyRH
 - dav-pascual


### PR DESCRIPTION
Signed-off-by: Armando Neto <abiagion@redhat.com>