### PR TITLE
Assign ssidhaye's jobs to gkaihorodova

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -18,7 +18,7 @@ nightly_jobs:
     flow: "ci"
     branch: "master"
     prci_config: "nightly_latest.yaml"
-    reviewer: ssidhaye
+    reviewer: gkaihorodova
 
   - name: testing_master_previous
     weekdays: "2"
@@ -135,7 +135,7 @@ nightly_jobs:
     flow: "ci"
     branch: "master"
     prci_config: "nightly_latest_sssd.yaml"
-    reviewer: ssidhaye
+    reviewer: gkaihorodova
 
   - name: testing_ipa-4.10_previous
     weekdays: "1"


### PR DESCRIPTION
Due to organizational restructuration, assign Sumedh's nightly runs to Ganna.

Signed-off-by: Michal Polovka <mpolovka@redhat.com>