### PR TITLE
Increase controller memory

### DIFF
--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -6,7 +6,7 @@
 # ad_master: &ad_master
 #   name: ad_master
 #   cpu: 4
-#   memory: 12000
+#   memory: 8096
 
 Vagrant.configure(2) do |config|
 
@@ -42,8 +42,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -6,7 +6,7 @@
 # ad_master_2client: &ad_master_2client
 #   name: ad_master_2client
 #   cpu: 4
-#   memory: 12000
+#   memory: 10596
 
 Vagrant.configure(2) do |config|
 
@@ -42,8 +42,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
+++ b/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
@@ -6,7 +6,7 @@
 # ad_root_child_tree_master_1client: &ad_root_child_tree_master_1client
 #   name: ad_root_child_tree_master_1client
 #   cpu: 8
-#   memory: 14500
+#   memory: 14466
 
 Vagrant.configure(2) do |config|
 
@@ -42,8 +42,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# build: &build
+#   name: build
+#   cpu: 2
+#   memory: 3800
 
 Vagrant.configure(2) do |config|
 

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# ipaserver: &ipaserver
+#   name: ipaserver
+#   cpu: 2
+#   memory: 2750
 
 Vagrant.configure(2) do |config|
 

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# master_1repl: &master_1repl
+#   name: master_1repl
+#   cpu: 4
+#   memory: 6750
 
 Vagrant.configure(2) do |config|
 
@@ -36,8 +42,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# master_1repl_1client: &master_1repl_1client
+#   name: master_1repl_1client
+#   cpu: 4
+#   memory: 8000
 
 Vagrant.configure(2) do |config|
 
@@ -35,8 +41,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# master_2repl_1client: &master_2repl_1client
+#   name: master_2repl_1client
+#   cpu: 4
+#   memory: 10750
 
 Vagrant.configure(2) do |config|
 
@@ -35,8 +41,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.master_3client
+++ b/templates/vagrantfiles/Vagrantfile.master_3client
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# master_3client: &master_3client
+#   name: master_3client
+#   cpu: 4
+#   memory: 7750
 
 Vagrant.configure(2) do |config|
 
@@ -35,8 +41,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
+# Add the following to the topologies section of your test definitions:
+#
+# master_3repl_1client: &master_3repl_1client
+#   name: master_3repl_1client
+#   cpu: 4
+#   memory: 13500
 
 Vagrant.configure(2) do |config|
 
@@ -35,8 +41,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "controller" , primary: true do |controller|
         controller.vm.provider "libvirt" do |domain,override|
-            # Less resources needed for controller
-            domain.memory = 950
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
         end
 
         controller.vm.provision :ansible do |ansible|


### PR DESCRIPTION
The `dnf install` commands were consuming more memory and failing the related tasks.
More info: https://github.com/freeipa-pr-ci2/freeipa/pull/2228#issuecomment-1328874034

Controller now have the same amount as client vms.

The `memory` property was also updated/added to all templates. 
Later, the definitions at the freeipa repo must be updated.
However, based on the numbers here, nothing should change. Those numbers, memory and cpu, are used to check if a job can be run. Since we have only two types of runners, jobs will fall in the same sized runner as now.

Small runners have, in average, 6.9Gi free when in idle; and big runners 14Gi.

I'm going to deploy this right now to the nightly runners and re-run some f36 PR.