### PR TITLE
Stop the nightly tests on fedora35

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -65,15 +65,6 @@ nightly_jobs:
     prci_config: "nightly_ipa-4-9_latest.yaml"
     reviewer: miskopo
 
-  - name: testing_ipa-4.9_previous
-    weekdays: "6"
-    hour: "15"
-    minute: "00"
-    flow: "ci"
-    branch: "ipa-4-9"
-    prci_config: "nightly_ipa-4-9_previous.yaml"
-    reviewer: menonsudhir
-
   - name: testing_master_pki
     weekdays: "7"
     hour: "20"


### PR DESCRIPTION
Fedora 35 is now EOL and we can stop running the nightlies with this version.
https://fedorapeople.org/groups/schedule/f-35/f-35-all-milestones-tasks.html

Remove testing_ipa-4-9_previous from the scheduler.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>