### PR TITLE
Contributor list: add Nihlus

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -40,6 +40,7 @@
 - mrizwan93
 - ndehadrai
 - netoarmando
+- Nihlus
 - pavelpicka
 - pvoborni
 - rcritten


### PR DESCRIPTION
Add Jarl Gullberg (Nihlus) to the contributors list, so that his new PRs automatically trigger gating tests.