### PR TITLE
fix: remove unsupported Ansible parameter 'warn'

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -42,14 +42,10 @@
 
 - name: "configure custom COPR repo ({{ copr }})"
   shell: "dnf copr enable -y {{ copr }}"
-  args:
-    warn: false
   when: copr is defined and copr
 
 - name: enable updates-testing repository
   shell: "dnf config-manager --set-enabled updates-testing"
-  args:
-    warn: false
   when: enable_testing_repo is defined and enable_testing_repo
 
 - name: update packages

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -75,8 +75,6 @@
   block:
     - name: enable winrm copr repo
       shell: "dnf copr enable -y @freeipa/freeipa-pr-ci"
-      args:
-        warn: no
     - name: install packages and their dependencies
       dnf:
         state: present

--- a/ansible/roles/utils/tasks/enable_swap.yml
+++ b/ansible/roles/utils/tasks/enable_swap.yml
@@ -5,7 +5,6 @@
       dd if=/dev/zero of={{ swapfile_file }} count={{ swapfile_size }} bs=1MB
     args:
       creates: "{{ swapfile_file }}"
-      warn: false
     register: write_swap_file
 
   - name: set swap file permissions
@@ -18,16 +17,12 @@
   - name: create swap file
     command: >
       mkswap {{ swapfile_file }}
-    args:
-      warn: false
     when: write_swap_file is changed
     register: create_swap_file
 
   - name: enable swapfile
     command: >
       swapon {{ swapfile_file }}
-    args:
-      warn: false
     when: create_swap_file is changed
 
   - name: add swapfile to /etc/fstab


### PR DESCRIPTION
'warn' parameter for 'args' was deprecated and removed in newer Ansible verions (e.g. the one on Fedora 37+).

Removal is required for successful run of runner deployment playbooks.