### PR TITLE
Change Windows image to Windows Server 2022

### DIFF
--- a/ansible/roles/windows/sshd/tasks/main.yml
+++ b/ansible/roles/windows/sshd/tasks/main.yml
@@ -10,12 +10,12 @@
 
 - when: not sshd_status.exists
   block:
-  - name: donwload cygwin installer
+  - name: Download cygwin installer
     win_get_url:
       url: "{{ cygwin_installer_url }}"
       dest: "{{ cygwin_installer_local_file }}"
 
-  - name: Install OpenSSH
+  - name: Install cygwin OpenSSH
     win_shell: >
       {{ cygwin_installer_local_file }}
       --quiet-mode
@@ -25,7 +25,7 @@
       --packages openssh
     failed_when: "'Installation incomplete' in (cygwin_result.stdout + cygwin_result.stderr)"
     register: cygwin_result
-    ignore_errors: yes
+    ignore_errors: true
     with_items: "{{ cygwin_mirror_urls }}"
     when: cygwin_result is undefined or cygwin_result.failed
 
@@ -52,7 +52,7 @@
     creates: "{{ cygwin_dir }}/etc/ssh_config"
   register: ssh_config
 
-- name: start sshd
+- name: Start cygwin sshd
   win_service:
     name: "{{ sshd_service }}"
     state: "{{ 'restarted' if passwd is changed or ssh_config is changed else 'started' }}"

--- a/ansible/roles/windows/sshd/tasks/main.yml
+++ b/ansible/roles/windows/sshd/tasks/main.yml
@@ -1,4 +1,9 @@
-- name: Check if sshd service exists
+- name: Turn off build-in OpenSSH server
+  win_service:
+    name: "sshd"
+    state: "absent"
+
+- name: Check if cygwin sshd service exists
   win_service:
     name: "{{ sshd_service }}"
   register: sshd_status

--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -55,7 +55,7 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.define "ad-root" do |ad_root|
-        ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
+        ad_root.vm.box = "freeipa/windows-server-2022-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
         {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
         ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -55,7 +55,7 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.define "ad-root" do |ad_root|
-        ad_root.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
+        ad_root.vm.box = "freeipa/windows-server-2022-standard-x64-eval"
         ad_root.vm.box_version = ">=0"
         {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
         ad_root.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true

--- a/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
+++ b/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
@@ -56,7 +56,7 @@ Vagrant.configure(2) do |config|
 
     ["ad-root", "ad-child", "ad-tree"].each do |hostname|
         config.vm.define hostname do |host|
-            host.vm.box = "freeipa/windows-server-2016-standard-x64-eval"
+            host.vm.box = "freeipa/windows-server-2022-standard-x64-eval"
             host.vm.box_version = ">=0"
             {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
             host.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true


### PR DESCRIPTION
**replace vagrant win-2016 box with win-2022**

To help fixing:
https://pagure.io/freeipa/issue/9124#comment-850025


**fix ansible linter messages in windows/sshd role**

- start plays with capital letters
- use true/false for booleans


**disable build-in OpenSSH server for Win 2022**

FreeIPA test suites expect that the default shell after SSHing into
windows machine is bash with core utils installed.

The new Win 2022 image comes with new Windows 2022 feature - OpenSSH
server. The SSH server works, but doesn't meet the expectation. Thus
it is disabled to not conflict with Cygwin OpenSSH server. Using cygwin
also fullfils the bash with core utils part.


Signed-off-by: Petr Vobornik <pvoborni@redhat.com>