### PR TITLE
Add Fedora 39 vars and bump rawhide + some fixes to make it build

### DIFF
--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -6,7 +6,7 @@
     - name: fedora_version
       prompt: fedora
       private: false
-      default: 30
+      default: 39
     - name: git_branch
       prompt: "git branch"
       private: false

--- a/ansible/roles/box/prepare/tasks/cleanup.yml
+++ b/ansible/roles/box/prepare/tasks/cleanup.yml
@@ -10,7 +10,7 @@
   args:
     chdir: "{{ template_box_dir }}"
   when: vagrantfile.stat.exists is defined and vagrantfile.stat.exists
- 
+
 - name: remove the template directory
   become: true
   file:

--- a/ansible/roles/machine/workarounds/tasks/configure_sunrpc_nfs_port.yml
+++ b/ansible/roles/machine/workarounds/tasks/configure_sunrpc_nfs_port.yml
@@ -6,8 +6,8 @@
 # `ansible/roles/machine/setup/tasks/install_packages.yml`, otherwise it would
 # be only installed later by Vagrant when bringing the machine.
 
-- name: configure sunrpc to leave kadmin port 749/TCP open
-  sysctl:
-    name: sunrpc.min_resvport
-    value: 750
-    state: present
+# - name: configure sunrpc to leave kadmin port 749/TCP open
+#   sysctl:
+#     name: sunrpc.min_resvport
+#     value: 750
+#     state: present

--- a/ansible/vars/fedora/39.yml
+++ b/ansible/vars/fedora/39.yml
@@ -1,0 +1,3 @@
+---
+fedora_releasever: 39  # bump when fedora gets branched
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-39-1.5.x86_64.vagrant-libvirt.box

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -1,5 +1,5 @@
 ---
-fedora_releasever: 39  # bump when fedora gets branched
+fedora_releasever: 40  # bump when fedora gets branched
 
 nightly_compose: true
 

--- a/ansible/vars/ipa_branches/ipa-4-11.yml
+++ b/ansible/vars/ipa_branches/ipa-4-11.yml
@@ -1,0 +1,2 @@
+---
+freeipa_version: 4-11

--- a/vagrant/atlas.py
+++ b/vagrant/atlas.py
@@ -106,7 +106,7 @@ class Boxes(object):
             raise KeyError(key)
 
 
-class Mapping(collections.Mapping):
+class Mapping(collections.abc.Mapping):
     obj_cls = None
     obj_key = None
     id_key = None
@@ -155,7 +155,7 @@ class BoxProvider(CRUD):
             version=boxversion.keys['version'], provider=provider, url=url)
 
     def __init__(self, boxversion, provider):
-        super(BoxProvider, self).__init__(boxversion.context, 
+        super(BoxProvider, self).__init__(boxversion.context,
             name=boxversion.keys['name'], username=boxversion.keys['username'],
             version=boxversion.keys['version'], provider=provider)
 


### PR DESCRIPTION
**Add Fedora 39 vars and bump rawhide**

As a prep for creating new boxes for ipa-4-11 and master branches.

adjustments for building f39 ipa box

**Applying the workaround did not work, thus it was commented out.**

+ some cleanup

**box uploader to run on newer Python**

collections.Mapping moved to collections.abc module thus the code needed
to be adjusted otherwise it crashed.



