### PR TITLE
Fixes for F39 runner

### DIFF
--- a/ansible/cleanup_runner_disk.yml
+++ b/ansible/cleanup_runner_disk.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: cleanup_runners
-  remote_user: root
+  become: true
+  become_method: sudo
   name: cleanup runners disk
   gather_facts: false
 

--- a/ansible/prepare_devel_test_runners.yml
+++ b/ansible/prepare_devel_test_runners.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: runners_devel
-  remote_user: root
+  become: true
+  become_method: sudo
   name: prepare development test runners
   vars_prompt:
     - name: monitored_repo_owner

--- a/ansible/prepare_openclose_pr_tool.yml
+++ b/ansible/prepare_openclose_pr_tool.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: scheduler
-  remote_user: root
+  become: true
+  become_method: sudo
   name: deploy open_close_pr tool
   gather_facts: yes
   vars:

--- a/ansible/prepare_test_runners.yml
+++ b/ansible/prepare_test_runners.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: runners
-  remote_user: root
+  become: true
+  become_method: sudo
   name: prepare production test runners
   vars_prompt:
     - name: github_token

--- a/ansible/roles/automation/setup/tasks/main.yml
+++ b/ansible/roles/automation/setup/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: setup.yml
-- include: ../../../runner/tasks/enable_nested_virt.yml
+- include_tasks: setup.yml
+- include_tasks: ../../../runner/tasks/enable_nested_virt.yml

--- a/ansible/roles/box/prepare/tasks/main.yml
+++ b/ansible/roles/box/prepare/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: cleanup.yml
+- include_tasks: cleanup.yml
   tags: cleanup
 
-- include: download_nightly_box.yml
+- include_tasks: download_nightly_box.yml
   when: nightly_compose is defined and nightly_compose
   tags:
     - download_nightly_box

--- a/ansible/roles/builder/build/tasks/main.yml
+++ b/ansible/roles/builder/build/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: prepare.yml
-- include: clone_git_repo.yml
-- include: check_4_5_build_system.yml
-- include: generate_build_version.yml
-- include: create_spec.yml
-- include: create_sources.yml
-- include: create_rpms.yml
+- include_tasks: prepare.yml
+- include_tasks: clone_git_repo.yml
+- include_tasks: check_4_5_build_system.yml
+- include_tasks: generate_build_version.yml
+- include_tasks: create_spec.yml
+- include_tasks: create_sources.yml
+- include_tasks: create_rpms.yml
 

--- a/ansible/roles/builder/cleanup/tasks/main.yml
+++ b/ansible/roles/builder/cleanup/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: remove_directories.yml
+- include_tasks: remove_directories.yml
 

--- a/ansible/roles/machine/cleanup/tasks/main.yml
+++ b/ansible/roles/machine/cleanup/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: clean_caches.yml
-- include: clean_hostname.yml
-- include: clean_dhcp_state.yml
-- include: clean_mac_addresses.yml
-- include: clean_logs.yml
-- include: clean_vagrant_temp.yml
-- include: clean_history.yml
+- include_tasks: clean_caches.yml
+- include_tasks: clean_hostname.yml
+- include_tasks: clean_dhcp_state.yml
+- include_tasks: clean_mac_addresses.yml
+- include_tasks: clean_logs.yml
+- include_tasks: clean_vagrant_temp.yml
+- include_tasks: clean_history.yml
 

--- a/ansible/roles/machine/setup/tasks/main.yml
+++ b/ansible/roles/machine/setup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: configuration.yml
-- include: setup_rng.yml
-- include: install_packages.yml
-- include: manage_ssh_keys.yml
+- include_tasks: configuration.yml
+- include_tasks: setup_rng.yml
+- include_tasks: install_packages.yml
+- include_tasks: manage_ssh_keys.yml
 

--- a/ansible/roles/machine/workarounds/tasks/main.yml
+++ b/ansible/roles/machine/workarounds/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: create_custodia_user.yml
-- include: vagrant_systemctl_no_pager.yml
-- include: configure_sunrpc_nfs_port.yml
+- include_tasks: create_custodia_user.yml
+- include_tasks: vagrant_systemctl_no_pager.yml
+- include_tasks: configure_sunrpc_nfs_port.yml
 

--- a/ansible/roles/runner/files/prci.service
+++ b/ansible/roles/runner/files/prci.service
@@ -9,8 +9,6 @@ User=root
 Group=root
 WorkingDirectory=/root/freeipa-pr-ci
 ExecStart=/bin/bash -c 'PYTHONPATH=$PYTHONPATH:/root/freeipa-pr-ci /root/freeipa-pr-ci/github/prci.py "$(hostname -s)" --config /root/.config/freeipa-pr-ci/config.yml'
-StandardOutput=syslog
-StandardError=syslog
 Restart=on-failure
 RestartSec=3m
 

--- a/ansible/roles/runner/tasks/custom_vagrant_catalog.yml
+++ b/ansible/roles/runner/tasks/custom_vagrant_catalog.yml
@@ -25,9 +25,3 @@
 
 - name: systemd daemon reload
   shell: systemctl daemon-reload
-
-- name: restart prci
-  service:
-    name: prci
-    enabled: true
-    state: restarted

--- a/ansible/roles/runner/tasks/deploy_pr_ci.yml
+++ b/ansible/roles/runner/tasks/deploy_pr_ci.yml
@@ -48,4 +48,3 @@
   service:
     name: prci
     enabled: true
-    state: started

--- a/ansible/roles/runner/tasks/main.yml
+++ b/ansible/roles/runner/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
-- include: manage_ssh_keys.yml
+- include_tasks: manage_ssh_keys.yml
   when: deploy_ssh_key
   tags: deployment
-- include: add_cloud_conf_files.yml
+- include_tasks: add_cloud_conf_files.yml
   tags: cloud_upload
-- include: enable_nested_virt.yml
+- include_tasks: enable_nested_virt.yml
   when: enable_nested_virt
   tags: nested_virt
-- include: setup.yml
-- include: create_libvirt_pool.yml
-- include: deploy_pr_ci.yml
-- include: autocleaner.yml
+- include_tasks: setup.yml
+- include_tasks: create_libvirt_pool.yml
+- include_tasks: deploy_pr_ci.yml
+- include_tasks: autocleaner.yml
   when: activate_autocleaner
-- include: custom_vagrant_catalog.yml
+- include_tasks: custom_vagrant_catalog.yml
 
 - include_role:
     name: utils

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -116,3 +116,14 @@
     regexp: '^#?SystemMaxUse'
     line: 'SystemMaxUse={{ limit_size_systemd_journal }}'
     state: present
+
+- name: Enable DNSSEC in /etc/systemd/resolved.conf
+  lineinfile:
+    path: /etc/systemd/resolved.conf
+    regexp: '^#?DNSSEC='
+    line: 'DNSSEC=yes'
+
+- name: Restart systemd-resolved service to reflect configuration changes
+  systemd:
+    name: systemd-resolved.service
+    state: restarted

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -94,11 +94,11 @@
 - name: force reinstall python3-six
   raw: dnf reinstall python3-six -y
 
-- name: configure sunrpc to leave kadmin port 749/TCP open
-  sysctl:
-    name: sunrpc.min_resvport
-    value: 750
-    state: present
+# - name: configure sunrpc to leave kadmin port 749/TCP open
+#   sysctl:
+#     name: sunrpc.min_resvport
+#     value: 750
+#     state: present
 
 - name: start&enable nfs
   service:

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -15,6 +15,17 @@
     name: "*"
     state: latest
 
+# TODO: Replace COPR repo when the packages hit the stable repos
+- name: enable winrm copr repo
+  shell: "dnf copr enable -y @freeipa/freeipa-pr-ci"
+- name: install winrm packages and their dependencies
+  dnf:
+    state: present
+    name:
+      - rubygem-winrm
+      - rubygem-winrm-fs
+      - rubygem-winrm-elevated
+
 - name: install runner dependencies
   dnf:
     state: present
@@ -46,43 +57,14 @@
   notify:
     - restart_nfs
 
-- name: register vagrant version
-  shell: vagrant --version | awk '{print $2}'
-  register: vagrant_version
-
 # as per sssd-suite readme file states, we need vagrant plugins...
 - name: install libvirt plugin for vagrant
   raw: vagrant plugin install vagrant-libvirt
-  ignore_errors: yes
+  ignore_errors: true
 
-- name: install vagrant plugin (winrm) for AD tests
-  raw: vagrant plugin install winrm
-  when: vagrant_version.stdout is version('2.2.0', '<')
-  ignore_errors: yes
-
-- name: install vagrant plugins (winrm-fs) for AD tests
-  raw: vagrant plugin install winrm-fs
-  when: vagrant_version.stdout is version('2.2.0', '<')
-  ignore_errors: yes
-
-- name: install vagrant plugins (winrm-elevated) for AD tests
-  raw: vagrant plugin install winrm-elevated
-  when: vagrant_version.stdout is version('2.2.0', '<')
-  ignore_errors: yes
-
-# TODO: Replace COPR repo when the packages hit the stable repos
-- name: install winrm packages and dependencies for AD tests
-  block:
-    - name: enable winrm copr repo
-      shell: "dnf copr enable -y @freeipa/freeipa-pr-ci"
-    - name: install packages and their dependencies
-      dnf:
-        state: present
-        name:
-          - rubygem-winrm
-          - rubygem-winrm-fs
-          - rubygem-winrm-elevated
-  when: vagrant_version.stdout is version('2.2.0', '>=')
+- name: install vagrant-sshfs plugin for vagrant
+  raw: vagrant plugin install vagrant-sshfs
+  ignore_errors: true
 
 # adding after packages install as the file can be overwritten by "mailcap"
 - name: add mime.types so awscli can correctly guess content-types

--- a/ansible/roles/runner/tasks/setup.yml
+++ b/ansible/roles/runner/tasks/setup.yml
@@ -26,6 +26,10 @@
       - rubygem-winrm-fs
       - rubygem-winrm-elevated
 
+# Use Hashicorp Vagrant (mostly will be newer than Fedora's)
+- name: enable Hashicorp repo
+  shell: "dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo"
+
 - name: install runner dependencies
   dnf:
     state: present

--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision_ad.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.ad_master
+++ b/templates/vagrantfiles/Vagrantfile.ad_master
@@ -64,6 +64,7 @@ Vagrant.configure(2) do |config|
         {% endif %}
 
         ad_root.vm.provider "libvirt" do |domain, override|
+            domain.graphics_type = "spice"
             domain.cpus = 2
             domain.memory = 4096
         end

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision_ad.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.ad_master_2client
+++ b/templates/vagrantfiles/Vagrantfile.ad_master_2client
@@ -64,6 +64,7 @@ Vagrant.configure(2) do |config|
         {% endif %}
 
         ad_root.vm.provider "libvirt" do |domain, override|
+            domain.graphics_type = "spice"
             domain.cpus = 2
             domain.memory = 4096
         end

--- a/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
+++ b/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision_ad.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
+++ b/templates/vagrantfiles/Vagrantfile.adroot_adchild_adtree_master_1client
@@ -65,6 +65,7 @@ Vagrant.configure(2) do |config|
             {% endif %}
 
             host.vm.provider "libvirt" do |domain, override|
+                domain.graphics_type = "spice"
                 domain.cpus = 2
                 domain.memory = 3072
             end

--- a/templates/vagrantfiles/Vagrantfile.build
+++ b/templates/vagrantfiles/Vagrantfile.build
@@ -41,6 +41,7 @@ Vagrant.configure(2) do |config|
 
         builder.vm.provision "ansible" do |ansible|
             ansible.playbook = "../../ansible/dummy.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.ipaserver
+++ b/templates/vagrantfiles/Vagrantfile.ipaserver
@@ -45,6 +45,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision_ipaserver.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 end

--- a/templates/vagrantfiles/Vagrantfile.master_1repl
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.master_1repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_1repl_1client
@@ -50,6 +50,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.master_2repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_2repl_1client
@@ -50,6 +50,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.master_3client
+++ b/templates/vagrantfiles/Vagrantfile.master_3client
@@ -50,6 +50,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 

--- a/templates/vagrantfiles/Vagrantfile.master_3repl_1client
+++ b/templates/vagrantfiles/Vagrantfile.master_3repl_1client
@@ -50,6 +50,7 @@ Vagrant.configure(2) do |config|
             ansible.limit = "all"
             ansible.playbook = "../../ansible/provision.yml"
             ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
         end
     end
 


### PR DESCRIPTION
These are fixes to be able to deploy and run task on F39 runner.

Rebased on: https://github.com/freeipa/freeipa-pr-ci/pull/493 


**fix: use ansible.compatibility_mode = "2.0" in Vagrantfiles**

Needed with newer version of Ansible (on F39) so that generated
Ansible inventory is using ansible_host, ansible_user, ansible_password
instead of ansible_ssh_{host,user,password}.

I.e. so that prci can connect to Windows hosts.


**fix: use hashicorp vagrant**

Instead of the one on Fedora.

Reason: atm Fedora 39 has Vagrant 2.3.4, but we need 2.3.9 to fix winrm
auth issue:
```
ERROR warden: Error occurred: An error occurred executing a remote WinRM command.

Shell: Cmd
Command: hostname
Message: Digest initialization failed: initialization error
```


**fix: cleanup vagrant installation**

- remove support for vagrant  < 2.2
- explicitely install vagrant-sshfs plugin


**fix: remove obsolete logging config from service file**

systemd reported that the logging options are obsolete and should be
removed. Thus removing.


**fix: explicitly define spice graphic for Windows vms**

Otherwise it fails with:
```
Error while creating domain: Error saving the server: Call to virDomainDefineXML
failed: unsupported configuration: chardev 'spicevmc' not supported without spice
graphics
```


**fix: comment out configuration of sunrpc**

As it fails on Fedora 39.


**fix: replace remote_user: root with become**

So that the playbook works if Ansible is connecting as a different user.


**fix: change deprecated ansible include to include_tasks**

To remove depracation warning and to work in a future.

