### PR TITLE
autocleaner: replace calls to deprecated ruamel.yaml.safe_load method

### DIFF
--- a/autocleaner.py
+++ b/autocleaner.py
@@ -88,7 +88,8 @@ def load_yaml(yml_path):
     """
     try:
         with open(yml_path) as yml_file:
-            return ruamel.yaml.safe_load(yml_file)
+            yaml = ruamel.yaml.YAML(typ='safe', pure=True)
+            return yaml.load(yml_file)
     except IOError as exc:
         logger.error('Failed to open %s: %s', yml_path, exc)
         sys.exit(1)
@@ -270,7 +271,8 @@ class PRCIDef():
         """
         Get template name and version
         """
-        templ_dict = self.get_templ_list(ruamel.yaml.safe_load(yaml_data))
+        yaml = ruamel.yaml.YAML(typ='safe', pure=True)
+        templ_dict = self.get_templ_list(yaml.load(yaml_data))
         templ_name = templ_dict['name']
         templ_ver = templ_dict['version']
         return templ_name, templ_ver


### PR DESCRIPTION
The method ruamel.yaml.safe_load(yml_file) has been deprecated with ruamel.yaml 0.15.0. Use instead:
  yaml = YAML(typ='safe', pure=True)
  yaml.load(...)

Fixes: https://github.com/freeipa/freeipa-pr-ci/issues/495