### PR TITLE
Nightly tests schedule: add tests for ipa-4-11

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -119,15 +119,6 @@ nightly_jobs:
     prci_config: "nightly_latest_sssd.yaml"
     reviewer: miskopo
 
-  - name: testing_ipa-4.10_previous
-    weekdays: "1"
-    hour: "08"
-    minute: "00"
-    flow: "ci"
-    branch: "ipa-4-10"
-    prci_config: "nightly_ipa-4-10_previous.yaml"
-    reviewer: flo-renaud
-
   - name: testing_ipa-4.10_latest
     weekdays: "2"
     hour: "11"

--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -119,6 +119,24 @@ nightly_jobs:
     prci_config: "nightly_latest_sssd.yaml"
     reviewer: miskopo
 
+  - name: testing_ipa-4.11_latest
+    weekdays: "1"
+    hour: "08"
+    minute: "00"
+    flow: "ci"
+    branch: "ipa-4-11"
+    prci_config: "nightly_ipa-4-11_latest.yaml"
+    reviewer: flo-renaud
+
+  - name: testing_ipa-4.11_latest_selinux
+    weekdays: "5"
+    hour: "07"
+    minute: "00"
+    flow: "ci"
+    branch: "ipa-4-11"
+    prci_config: "nightly_ipa-4-11_latest_selinux.yaml"
+    reviewer: flo-renaud
+
   - name: testing_ipa-4.10_latest
     weekdays: "2"
     hour: "11"


### PR DESCRIPTION
### Nightly tests: stop testing ipa-4-10 on fedora37

ipa-4-10 branch is currently tested on fedora 37 (labelled as
ipa-4-10_previous) and 38 (labelled as ipa-4-10-latest).
As fedora 37 is EOL, stop the tests on f37.

### Nightly tests: schedule tests for ipa-4-11 branch

The tests for ipa-4-11 branch will now be scheduled:
- Monday 8h for ipa-4-11 latest (fedora 39)
- Friday 7h for ipa-4-11 latest with selinux (fedora 39)

Ticket: FREEIPA-10719