### PR TITLE
machine/provision role: force pki upgrade using --allowerasing

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -54,6 +54,14 @@
     state: latest
   when: update_packages is defined and update_packages
 
+# Workaround for pki upgrade issue
+- name: update pki packages
+  dnf:
+    name: 'dogtag-pki-server'
+    state: latest
+    allowerasing: true
+  when: update_packages is defined and update_packages
+
 - name: update pip packages
   pip:
     executable: pip3


### PR DESCRIPTION
The nightly tests are not using the latest pki version because the upgrade from pki 11.4.3 to 11.5.0 requires dnf update --best --allowerasing.

Force the upgrade of pki in the machine/provision role using those options when updates_packages is set to true.

Fixes: https://github.com/freeipa/freeipa-pr-ci/issues/498