### PR TITLE
Add fedora 40 vars and ipa-4-12 branch

### DIFF
--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -38,6 +38,15 @@
     - vars/fedora/{{ fedora_version }}.yml
     - vars/ipa_branches/{{ git_branch }}.yml
   pre_tasks:
+    - name: Install cloud-utils-growpart for f40
+      when: fedora_version == '40'
+      command: dnf install -y cloud-utils-growpart
+    - name: grow partition size /dev/vda4 for f40
+      when: fedora_version == '40'
+      command: growpart /dev/vda 4
+    - name: resize the / filesystem for f40
+      when: fedora_version == '40'
+      command: btrfs filesystem resize max /
     # GPG keys might be outdated for packages in Rawhide
     - name: Update fedora-repos package
       when: nightly_compose is defined and nightly_compose

--- a/ansible/roles/box/prepare/templates/Vagrantfile.j2
+++ b/ansible/roles/box/prepare/templates/Vagrantfile.j2
@@ -17,6 +17,9 @@ Vagrant.configure(2) do |config|
         template.vm.provider "libvirt" do |domain,override|
             domain.memory = 2048
             override.vm.network "private_network", type: "dhcp"
+{% if fedora_version == '40' %}
+            domain.machine_virtual_size = 20
+{% endif %}
         end
 
     end

--- a/ansible/roles/machine/setup/tasks/configuration.yml
+++ b/ansible/roles/machine/setup/tasks/configuration.yml
@@ -1,4 +1,9 @@
 ---
+- name: install Python 3 deps for ansible modules
+  dnf:
+    name: python3-libselinux
+    state: latest
+
 - name: set selinux mode
   selinux:
     state: "{{ selinux_mode }}"

--- a/ansible/vars/fedora/40.yml
+++ b/ansible/vars/fedora/40.yml
@@ -1,0 +1,3 @@
+---
+fedora_releasever: 40
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt.x86_64-40-1.14.vagrant.libvirt.box

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -1,5 +1,5 @@
 ---
-fedora_releasever: 40  # bump when fedora gets branched
+fedora_releasever: 41  # bump when fedora gets branched
 
 nightly_compose: true
 

--- a/ansible/vars/ipa_branches/ipa-4-12.yml
+++ b/ansible/vars/ipa_branches/ipa-4-12.yml
@@ -1,0 +1,2 @@
+---
+freeipa_version: 4-12


### PR DESCRIPTION
The cloud base vagrant image for Fedora 40 has a small disk size (5G) by default.
Increase to 20G, grow the partition and extend the BTRFS to the max siz available.