### PR TITLE
Nightly tests: update the schedule

### DIFF
--- a/ansible/roles/automation/nightly_pr/defaults/main.yml
+++ b/ansible/roles/automation/nightly_pr/defaults/main.yml
@@ -47,14 +47,14 @@ nightly_jobs:
     prci_config: "nightly_ipa-4-6.yaml"
     reviewer: miskopo
 
-  - name: testing_ipa-4.9_latest
+  - name: testing_ipa-4.12_latest_selinux
     weekdays: "6"
     hour: "8"
     minute: "00"
     flow: "ci"
-    branch: "ipa-4-9"
-    prci_config: "nightly_ipa-4-9_latest.yaml"
-    reviewer: miskopo
+    branch: "ipa-4-12"
+    prci_config: "nightly_ipa-4-12_latest_selinux.yaml"
+    reviewer: b3lix
 
   - name: testing_master_pki
     weekdays: "7"
@@ -137,14 +137,14 @@ nightly_jobs:
     prci_config: "nightly_ipa-4-11_latest_selinux.yaml"
     reviewer: flo-renaud
 
-  - name: testing_ipa-4.10_latest
+  - name: testing_ipa-4.12_latest
     weekdays: "2"
     hour: "11"
     minute: "00"
     flow: "ci"
-    branch: "ipa-4-10"
-    prci_config: "nightly_ipa-4-10_latest.yaml"
-    reviewer: flo-renaud
+    branch: "ipa-4-12"
+    prci_config: "nightly_ipa-4-12_latest.yaml"
+    reviewer: b3lix
 
   - name: testing_ipa-4.10_latest_selinux
     weekdays: "4"


### PR DESCRIPTION
Changes compared to the current schedule:
- ipa-4-10_latest is removed (we keep ipa-4-10_latest_selinux)
- ipa-4-9_latest is removed (we keep ipa-4-9_latest_selinux)
- ipa-4-12_latest is added on Tuesdays, assigned to b3lix
- ipa-4-12_latest_selinux is added on Saturdays, assigned to b3lix