### PR TITLE
Test multidomain

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -1,9 +1,14 @@
 ---
 git_repo: https://github.com/freeipa/freeipa.git
+ipa_domain: ipa.test
+trusted_domain: trustedipa.test
 ad_root_domain: ad.test
 ad_root_dc_hostname: ad-root
 ad_child_domain: child.ad.test
 ad_child_dc_hostname: ad-child
 ad_tree_domain: adtree.test
 ad_tree_dc_hostname: ad-tree
+trusted_master_hostname: trustedmaster
+trusted_replica_hostname: trustedreplica
+trusted_client_hostname: trustedclient
 

--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -117,6 +117,11 @@
 # workaround for https://github.com/ansible/ansible/issues/19814
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.ipa.test"
+  when: inventory_hostname == 'controller' or inventory_hostname == 'master' or inventory_hostname == 'client' or inventory_hostname == 'replica'
+
+- name: set hostname
+  shell: "hostnamectl set-hostname {{ inventory_hostname }}.trustedipa.test"
+  when: inventory_hostname == 'trustedmaster' or inventory_hostname == 'trustedclient' or inventory_hostname == 'trustedreplica'
 
 # Change selinux state if `selinux_enforcing: true` is set in test suite definition
 - name: set selinux to enforcing

--- a/ansible/roles/machine/provision/templates/hosts
+++ b/ansible/roles/machine/provision/templates/hosts
@@ -1,9 +1,14 @@
 127.0.0.1  localhost
 ::1  localhost
 {% for host in groups['all'] %}
-   {% if 'ansible_default_ipv4' in hostvars[host] %}
-      {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['inventory_hostname'] }}.ipa.test
-   {% endif %}
+{% if 'ansible_default_ipv4' in hostvars[host] %}
+{% if host.startswith('controller') or host.startswith('master') or host.startswith('replica') or host.startswith('client') %}
+{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['inventory_hostname'] }}.ipa.test
+{% endif %}
+{% if host.startswith('trustedmaster') or host.startswith('trustedreplica') or host.startswith('trustedclient') %}
+{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['inventory_hostname'] }}.trustedipa.test
+{% endif %}
+{% endif %}
 {% endfor %}
 
 {% for host, domain in [
@@ -12,6 +17,6 @@
   (ad_tree_dc_hostname, ad_tree_domain)
 ] %}
 {% if host in groups['all'] %}
-      {{ hostvars[host]['ansible_ip_addresses']|ipv4|first }} {{ host }}.{{ domain }}
+{{ hostvars[host]['ansible_ip_addresses']|ipv4|first }} {{ host }}.{{ domain }}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/machine/provision/templates/ipa-test-config.yaml
+++ b/ansible/roles/machine/provision/templates/ipa-test-config.yaml
@@ -27,6 +27,28 @@ domains:
   name: ipa.test
   type: IPA
 
+{% if trusted_domain %}
+- hosts:
+{% for host in groups['all'] %}
+{% if host.startswith('trustedmaster') or host.startswith('trustedreplica') or host.startswith('trustedclient') %}
+    - external_hostname: {{ hostvars[host]['inventory_hostname'] }}.trustedipa.test
+      name: {{ hostvars[host]['inventory_hostname'] }}.trustedipa.test
+      ip: {{ hostvars[host]['ansible_default_ipv4']['address'] }}
+{% if host.startswith('trustedmaster') %}
+      role: master
+{% endif %}
+{% if host.startswith('trustedreplica') %}
+      role: replica
+{% endif %}
+{% if host.startswith('trustedclient') %}
+      role: client
+{% endif %}
+{% endif %}
+{% endfor %}
+  name: trustedipa.test
+  type: TRUSTED_IPA
+{% endif %}
+
 {% for host, domain, domain_type in [
   (ad_root_dc_hostname, ad_root_domain, "AD"),
   (ad_child_dc_hostname, ad_child_domain, "AD_SUBDOMAIN"),

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -252,7 +252,7 @@ class RunPytest(JobTask):
     def __init__(self, template, build_url, test_suite, topology=None,
                  timeout=constants.RUN_PYTEST_TIMEOUT, update_packages=False,
                  xmlrpc=False, selinux_enforcing=False, fips=False, copr=None,
-                 enable_testing_repo=False, **kwargs):
+                 enable_testing_repo=False, trusted_domain=False, **kwargs):
         super(RunPytest, self).__init__(template, timeout=timeout, **kwargs)
         self.build_url = build_url + '/'
         self.test_suite = test_suite
@@ -262,7 +262,7 @@ class RunPytest(JobTask):
         self.xmlrpc = xmlrpc
         self.copr = copr
         self.enable_testing_repo = enable_testing_repo
-
+        self.trusted_domain = trusted_domain
         if not topology:
             topology = {'name': constants.DEFAULT_TOPOLOGY}
 
@@ -292,6 +292,7 @@ class RunPytest(JobTask):
                     "fips": self.fips,
                     "copr": self.copr,
                     "enable_testing_repo": self.enable_testing_repo,
+                    "trusted_domain": self.trusted_domain,
                 },
             )
         except (OSError, IOError) as exc:
@@ -415,3 +416,5 @@ class RunWebuiTests(RunPytest):
 
 class RunADTests(RunPytest):
     action_name = 'ad'
+
+

--- a/templates/run_pytest.vars.yml
+++ b/templates/run_pytest.vars.yml
@@ -6,4 +6,5 @@ caless: {{ caless | default(false) }}
 fips: {{ fips | default(false) }}
 enable_testing_repo: {{ enable_testing_repo | default(false) }}
 ansible_python_interpreter: /usr/bin/python3
+trusted_domain: {{ trusted_domain | default(false) }}
 {% if copr %}copr: "{{ copr }}"{% endif %}

--- a/templates/vagrantfiles/Vagrantfile.ipa_ipa_trust
+++ b/templates/vagrantfiles/Vagrantfile.ipa_ipa_trust
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# Add the following to the topologies section of your test definitions:
+#
+# ipa_ipa_trust: &ipa_ipa_trust
+#   name: ipa_ipa_trust
+#   cpu: 7
+#   memory: 14750
+
+Vagrant.configure(2) do |config|
+
+    config.ssh.username = "root"
+
+    config.vm.synced_folder "./", "/vagrant",
+    {% if vagrant_template_name == "freeipa/ci-ipa-4-6-f27" %}
+        type: "nfs", nfs_udp: false
+    {% else %}
+        type: "sshfs", sshfs_opts_append: "-o cache=no"
+    {% endif %}
+
+    config.vm.box = "{{ vagrant_template_name }}"
+    config.vm.box_version = "{{ vagrant_template_version }}"
+
+    config.vm.provider "libvirt" do |domain, override|
+        # Defaults for masters and replica
+        # WARNING: Do not overcommit CPUs, it causes issues during
+        # provisioning, when RPMs are installed
+        domain.cpus = 1
+        domain.memory = 2750
+
+        # Nested virtualization options
+        domain.nested = true
+        domain.cpu_mode = "host-passthrough"
+
+        # Disable graphics
+        domain.graphics_type = "none"
+
+        domain.volume_cache = "unsafe"
+    end
+
+    config.vm.define "controller" , primary: true do |controller|
+        controller.vm.provider "libvirt" do |domain,override|
+            # Less resources needed for controller - same amount as the clients
+            domain.memory = 1250
+        end
+
+        controller.vm.provision :ansible do |ansible|
+            # Disable default limit to connect to all the machines
+            ansible.limit = "all"
+            ansible.playbook = "../../ansible/provision.yml"
+            ansible.extra_vars = "vars.yml"
+            ansible.compatibility_mode = "2.0"
+        end
+    end
+
+    config.vm.define "master"  do |master|
+    end
+
+    config.vm.define "trustedmaster"  do |trustedmaster|
+    end
+
+    config.vm.define "replica"  do |replica|
+    end
+
+    config.vm.define "trustedreplica"  do |trustedreplica|
+    end
+
+    config.vm.define "client"  do |client|
+        client.vm.provider "libvirt" do |domain,override|
+            domain.memory = 1250
+        end
+    end
+
+    config.vm.define "trustedclient"  do |trustedclient|
+        trustedclient.vm.provider "libvirt" do |domain,override|
+            domain.memory = 1250
+        end
+    end
+
+end


### PR DESCRIPTION
Add multidomain topology for ipa-replica-client
IPA multidomain topology is added for domain :
ipa.test and trustedipa.test

Related : https://issues.redhat.com/browse/FREEIPA-11087