### PR TITLE
Provision machines: fix hostname logic

### DIFF
--- a/ansible/roles/machine/provision/tasks/main.yml
+++ b/ansible/roles/machine/provision/tasks/main.yml
@@ -117,11 +117,11 @@
 # workaround for https://github.com/ansible/ansible/issues/19814
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.ipa.test"
-  when: inventory_hostname == 'controller' or inventory_hostname == 'master' or inventory_hostname == 'client' or inventory_hostname == 'replica'
+  when: inventory_hostname is not match("^trusted.*")
 
 - name: set hostname
   shell: "hostnamectl set-hostname {{ inventory_hostname }}.trustedipa.test"
-  when: inventory_hostname == 'trustedmaster' or inventory_hostname == 'trustedclient' or inventory_hostname == 'trustedreplica'
+  when: inventory_hostname is match("^trusted.*")
 
 # Change selinux state if `selinux_enforcing: true` is set in test suite definition
 - name: set selinux to enforcing


### PR DESCRIPTION
When the test machines are provisioned, the hostname must be set (otherwise the default hostname "localhost" is used.

The current logic relies on the inventory hostname being either master / client / replica / controller / trustedmaster / trustedclient / trustedreplica but depending on the Vagrant file the inventory hostname can also be client0 replica2 etc...

In this case the hostname is not set.

Change the logic to set the hostname to xx.ipa.test if the inventory_hostname does not contain trustedxx and to xx.trustedipa.test if the inventory_hostname contains trustedxx.