### PR TITLE
Cygwin installation: define default value in the loop

### DIFF
--- a/ansible/roles/windows/sshd/tasks/main.yml
+++ b/ansible/roles/windows/sshd/tasks/main.yml
@@ -27,7 +27,7 @@
     register: cygwin_result
     ignore_errors: true
     with_items: "{{ cygwin_mirror_urls }}"
-    when: cygwin_result is undefined or cygwin_result.failed
+    when: cygwin_result is undefined or cygwin_result.failed|d(false)
 
   - name: Check Cygwin installation status
     vars:


### PR DESCRIPTION
The playbook installing cygwin openssh contains a loop trying multiple mirrors until one of them succeeds. Ansible changed behavior and the result.failed variable is not set if the iteration succeeded.
Default to false if not set, so that the loop continues if the last iteration failed but is skipped if it succeeded.

Resolves: https://github.com/freeipa/freeipa-pr-ci/issues/512