### PR TITLE
Allow list: fix case for KoRORland

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -30,7 +30,7 @@
 - jhrozek
 - jrisc
 - kaleemsiddiqu
-- kororland
+- KoRORland
 - lslebodn
 - MartinBasti
 - madhuriupadhye


### PR DESCRIPTION
The user was added in lowercase but the allow list is case-sensitive.