### PR TITLE
Vagrant images: prepare for fedora 42 and fix rawhide

### DIFF
--- a/ansible/roles/box/prepare/tasks/download_nightly_box.yml
+++ b/ansible/roles/box/prepare/tasks/download_nightly_box.yml
@@ -11,8 +11,8 @@
 
 - name: download latest nightly box ({{ fedora_releasever }})
   shell: >
-    wget -r -np -nH --cut-dirs=9 -A
-    'Fedora-Cloud-Base-Vagrant-{{ fedora_version.capitalize() }}-*x86_64.vagrant-libvirt.box'
+    wget -r -np -nH --cut-dirs=9 --accept-regex
+    'Fedora-Cloud-Base-Vagrant-libvirt-{{ fedora_version.capitalize() }}-.*x86_64.vagrant.libvirt.box'
     {{ fedora_nightly_images_remote_dir }}
   args:
     chdir: "{{ fedora_nightly_template_dir }}"

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -8,7 +8,6 @@
 - name: remove packages that cause conflicts on rawhide
   dnf:
     name:
-      - gdbm
       - python2-chardet
     state: absent
   when: fedora_version in ['rawhide', '30']
@@ -59,12 +58,20 @@
       - vim
       - NetworkManager
       - xorg-x11-server-Xvfb
-      - firefox
       - python3-paramiko
       - python3-pip
       - firewalld
       - nfs-utils
       - kernel-modules
+
+# firefox installation may fail due to openh264 conflict
+# allowerasing to prevent install failure
+- name: install additional packages
+  dnf:
+    state: latest
+    allowerasing: true
+    name:
+      - firefox
 
 - name: install Ansible dependencies
   dnf:

--- a/ansible/vars/fedora/42.yml
+++ b/ansible/vars/fedora/42.yml
@@ -1,0 +1,3 @@
+---
+fedora_releasever: 42
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/test/42_Beta/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42_Beta-1.4.x86_64.vagrant.libvirt.box

--- a/ansible/vars/fedora/42.yml
+++ b/ansible/vars/fedora/42.yml
@@ -1,3 +1,3 @@
 ---
 fedora_releasever: 42
-base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/test/42_Beta/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42_Beta-1.4.x86_64.vagrant.libvirt.box
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -1,5 +1,5 @@
 ---
-fedora_releasever: 42  # bump when fedora gets branched
+fedora_releasever: 43  # bump when fedora gets branched
 
 nightly_compose: true
 


### PR DESCRIPTION
- The base image for Rawhide has been renamed and contains . instead of - for instance
Fedora-Cloud-Base-Vagrant-VirtualBox-Rawhide-20250325.n.0.x86_64.vagrant.virtualbox.box

- Prepare for f42 image, add variables and config file

## Summary by Sourcery

Prepare Vagrant image configuration for Fedora 42 and update Rawhide image handling

New Features:
- Add configuration for Fedora 42 Vagrant box
- Introduce a new variables file for Fedora 42

Enhancements:
- Update box download pattern to handle new Fedora image naming conventions
- Modify Firefox package installation to use allowerasing to prevent potential conflicts

Chores:
- Update Rawhide release version
- Adjust nightly box download regex to match new image naming