### PR TITLE
clean-install instead of install

### DIFF
--- a/ansible/roles/builder/build/tasks/create_sources.yml
+++ b/ansible/roles/builder/build/tasks/create_sources.yml
@@ -29,7 +29,7 @@
   when: webui.stat.exists
 
 - name: download node_modules for Modern WebUI
-  shell: npm install
+  shell: npm clean-install
   args:
     chdir: /root/freeipa/install/freeipa-webui
   when: webui.stat.exists


### PR DESCRIPTION
Makes build architecture agnostic.
This change probably changes nothing in pr-ci, but uses consistent commands with other places.