### PR TITLE
Box used to create Vagrant images: increase memory

### DIFF
--- a/ansible/roles/box/prepare/templates/Vagrantfile.j2
+++ b/ansible/roles/box/prepare/templates/Vagrantfile.j2
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.define "template"  do |template|
         template.vm.provider "libvirt" do |domain,override|
-            domain.memory = 2048
+            domain.memory = 4096
             override.vm.network "private_network", type: "dhcp"
 {% if fedora_version >= '40' %}
             domain.machine_virtual_size = 20


### PR DESCRIPTION
Now that freeipa also builds the modern webui using npm, the box needs to be bigger in terms of memory because npm build is greedy.

Switch from 2048 to 4096 MBytes