### PR TITLE
Vagrant box: prepare new rawhide box

### DIFF
--- a/ansible/create_template_box.yml
+++ b/ansible/create_template_box.yml
@@ -38,15 +38,18 @@
     - vars/fedora/{{ fedora_version }}.yml
     - vars/ipa_branches/{{ git_branch }}.yml
   pre_tasks:
-    - name: Install cloud-utils-growpart for f40
+    - name: Grow partition
+      block:
+      - name: Install cloud-utils-growpart for f40
+        command: dnf install -y cloud-utils-growpart
+      - name: find device for partition /
+        ansible.builtin.set_fact:
+          device: "{{ ansible_mounts | json_query('[?mount == `/`].device') }}"
+      - name: grow partition / size  for f40
+        command: growpart "{{ device[0][:-1] }}" "{{ device[0][-1] }}"
+      - name: resize the / filesystem for f40
+        command: btrfs filesystem resize max /
       when: fedora_version >= '40'
-      command: dnf install -y cloud-utils-growpart
-    - name: grow partition size /dev/vda4 for f40
-      when: fedora_version >= '40'
-      command: growpart /dev/vda 4
-    - name: resize the / filesystem for f40
-      when: fedora_version >= '40'
-      command: btrfs filesystem resize max /
     - name: Stat /usr/bin/dnf5
       ansible.builtin.stat:
         path: /usr/bin/dnf5

--- a/ansible/roles/box/prepare/tasks/download_nightly_box.yml
+++ b/ansible/roles/box/prepare/tasks/download_nightly_box.yml
@@ -11,7 +11,7 @@
 
 - name: download latest nightly box ({{ fedora_releasever }})
   shell: >
-    wget -r -np -nH --cut-dirs=9 --accept-regex
+    wget -e robots=off -r -np -nH --cut-dirs=9 --accept-regex
     'Fedora-Cloud-Base-Vagrant-libvirt-{{ fedora_version.capitalize() }}-.*x86_64.vagrant.libvirt.box'
     {{ fedora_nightly_images_remote_dir }}
   args:

--- a/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
+++ b/ansible/roles/builder/prepare/templates/mock-fedora-rawhide.cfg.j2
@@ -43,4 +43,5 @@ name=rawhide
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=$basearch
 failovermethod=priority
 enabled={{ repo_rawhide_enabled }}
+gpgkey=https://src.fedoraproject.org/rpms/fedora-repos/raw/rawhide/f/RPM-GPG-KEY-fedora-{{ fedora_releasever }}-primary
 """

--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -13,7 +13,7 @@
   when: fedora_version in ['rawhide', '30']
 
 - name: install freeipa rpms with dependencies
-  shell: dnf install -y /vagrant/rpms/*.rpm
+  shell: dnf --setopt pkg_gpgcheck=false install -y /vagrant/rpms/*.rpm
 
 - name: remove freeipa packages while keeping dependencies
   shell: "rpm -e --nodeps '{{ item }}'"
@@ -158,4 +158,4 @@
         url: "{{ download_metadata.json  | to_json | from_json | json_query(query) }}"
         dest: /opt/selenium.jar
       vars:
-        query: "assets[?content_type == 'raw'] | [?ends_with(name, 'jar')] | [?starts_with(name, 'selenium-server')].browser_download_url | [0]"
+        query: "assets[?content_type == 'application/java-archive'] | [?ends_with(name, 'jar')] | [?starts_with(name, 'selenium-server')].browser_download_url | [0]"

--- a/ansible/vars/fedora/rawhide.yml
+++ b/ansible/vars/fedora/rawhide.yml
@@ -1,5 +1,5 @@
 ---
-fedora_releasever: 44  # bump when fedora gets branched
+fedora_releasever: 45  # bump when fedora gets branched
 
 nightly_compose: true
 


### PR DESCRIPTION
- Rawhide is now mapped to Fedora 45.
- The template is using /dev/vda5 instead of /dev/vda4. Use ansible facts to find the right device name instead of hardcoding the value.
- Append -e robots=off to wget command to allow download from src.fedoraproject.org as the site is now protected against engine crawlers
- Update the query for selenium server (the site now exposes the jar with content_type: 'application/java-archive'
- Ignore pkg_gpgcheck when installing the freeipa rpms