### PR TITLE
Autocleaner: remove boxes for older branches

### DIFF
--- a/ansible/cleanup_runner_disk.yml
+++ b/ansible/cleanup_runner_disk.yml
@@ -47,4 +47,15 @@
           failed_when:
             res.rc != 0
             and "not found" not in res.stderr
+
+        - name: delete image with name _box.img from libvirt
+          shell: >
+            virsh vol-delete --pool default
+            {{ box_initial_name }}-{{ box_name }}_vagrant_box_image_{{ box_version }}_box.img
+          register: res
+          changed_when: res.rc == 0
+          failed_when:
+            res.rc != 0
+            and "not found" not in res.stderr
+
       when: user_confirmation == "YES" and box_name != "" and box_version != ""

--- a/autocleaner.py
+++ b/autocleaner.py
@@ -33,6 +33,8 @@ PRCI_DEF_DIR = 'ipatests/prci_definitions'
 LIBVIRT_IMAGES_DIR = '/var/lib/libvirt/images/'
 LIBVIRT_IMAGE_BASE = ('freeipa-VAGRANTSLASH-{name}_vagrant_box_image'
                       '_{version}.img')
+LIBVIRT_IMAGE_ALT_BASE = ('freeipa-VAGRANTSLASH-{name}_vagrant_box_image'
+                         '_{version}_box.img')
 VAGRANT_NO_BOXES = 'There are no installed boxes!'
 
 GH_RAW_PATH = 'https://raw.githubusercontent.com/{owner}/freeipa/{ref}/{path}'
@@ -347,6 +349,12 @@ class Box():
 
         subprocess.run(del_args, timeout=TIMEOUT)
 
+        del_args = ['virsh', 'vol-delete', '--pool', 'default',
+                    LIBVIRT_IMAGE_ALT_BASE.format(
+                        name=name, version=self.box_templ_ver)]
+
+        subprocess.run(del_args, timeout=TIMEOUT)
+
 
 def create_parser():
     """
@@ -371,7 +379,8 @@ def run(args):
     for vagrant_box in list_vagrant_boxes():
         logger.info('Checking if box %s is used', vagrant_box)
         box = Box(vagrant_box)
-        if not box.is_box_used:
+        # Delete boxes for older branches and unused boxes for master branch
+        if box.branch != "master" or not box.is_box_used:
             logger.info('Deleting %s', vagrant_box)
             box.delete_box()
             box.delete_libvirt_img()


### PR DESCRIPTION
1. When a PR is backported to older branches, the box gets downloaded but is not cleaned up as its definition remains in use for the ipa-4-x branch.
Change strategy and keep only the boxes for the master branch that are actually used.

2. The box name in /var/lib/libvirt/images does not always follow the format
    freeipa-VAGRANTSLASH-{name}_vagrant_box_image_{version}.img
We sometimes have instead
    freeipa-VAGRANTSLASH-{name}_vagrant_box_image_{version}_box.img

Call virsh vol-delete --pool default <name> with both.