### PR TITLE
Vagrant images: prepare for fedora 44

### DIFF
--- a/ansible/roles/machine/setup/tasks/install_packages.yml
+++ b/ansible/roles/machine/setup/tasks/install_packages.yml
@@ -158,4 +158,4 @@
         url: "{{ download_metadata.json  | to_json | from_json | json_query(query) }}"
         dest: /opt/selenium.jar
       vars:
-        query: "assets[?content_type == 'application/java-archive'] | [?ends_with(name, 'jar')] | [?starts_with(name, 'selenium-server')].browser_download_url | [0]"
+        query: "assets[?ends_with(name, 'jar')] | [?starts_with(name, 'selenium-server')].browser_download_url | [0]"

--- a/ansible/vars/fedora/44.yml
+++ b/ansible/vars/fedora/44.yml
@@ -1,0 +1,3 @@
+---
+fedora_releasever: 44
+base_box_url: https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-44-1.7.x86_64.vagrant.libvirt.box


### PR DESCRIPTION
- Vagrant images: prepare for fedora 44
- Create vagrant box: update the query for selenium download
Update the query for selenium server (the site sometimes exposes the jar
with content_type: 'application/java-archive', and sometimes with 'raw').